### PR TITLE
add concept dbus module & nic module that uses it

### DIFF
--- a/lib/linux_admin/dbus.rb
+++ b/lib/linux_admin/dbus.rb
@@ -1,0 +1,89 @@
+# LinuxAdmin DBus Interface
+#
+# Copyright (C) 2013 Red Hat Inc.
+# Licensed under the MIT License
+
+require "dbus"
+
+# example usage
+# s = LinuxAdmin::DBus.service "org.freedesktop.NetworkManager"
+# o = s.object '/org/freedesktop/NetworkManager'
+# i = o.interface
+# puts i['WirelessEnabled']
+# i['WirelessEnabled'] = false
+#
+class LinuxAdmin
+  class DBus < LinuxAdmin
+    def self.bus
+      ::DBus::SystemBus.instance
+    end
+
+    def self.service(id)
+      DBusService.new :id => id,
+                      :dbus_service => bus[id]
+    end
+  end
+
+  class DBusService
+    attr_accessor :id
+    attr_accessor :dbus_service
+
+    def initialize(args = {})
+      @id           = args[:id]
+      @dbus_service = args[:dbus_service]
+    end
+
+    def object(path)
+      DBusObject.new :dbus_object => @dbus_service.object(path),
+                     :service     => self
+    end
+
+  end
+
+  class DBusObject
+    attr_accessor :dbus_object
+    attr_accessor :service
+
+    def initialize(args = {})
+      @dbus_object = args[:dbus_object]
+      @service     = args[:service]
+      @dbus_object.introspect
+    end
+
+    def interface(id=nil)
+      id = service.id if id.nil?
+      DBusInterface.new :dbus_interface => @dbus_object[id],
+                        :object => self
+    end
+  end
+
+  class DBusInterface
+    attr_accessor :dbus_interface
+    attr_accessor :object
+
+    def initialize(args = {})
+      @dbus_interface = args[:dbus_interface]
+      @object         = args[:object]
+    end
+
+    # dispatch Get, [], []=, devices to to the interface
+    def get(i, v)
+      @dbus_interface.Get(i, v)
+    end
+
+    def [](i)
+      @dbus_interface[i]
+    end
+
+    def []=(i,v)
+      @dbus_interface[i] = v
+    end
+
+    def devices(interface = nil)
+      @dbus_interface.GetDevices.first.collect { |d|
+        o =  object.service.object d
+        interface.nil? ? o : o.interface(interface)
+      }
+    end
+  end
+end

--- a/lib/linux_admin/nic.rb
+++ b/lib/linux_admin/nic.rb
@@ -1,0 +1,31 @@
+# LinuxAdmin NIC Representation
+#
+# Copyright (C) 2013 Red Hat Inc.
+# Licensed under the MIT License
+
+require 'linux_admin/dbus'
+
+def inet_ntoa(n)
+  [n].pack("N").unpack("C*").reverse.join "."
+end
+
+class LinuxAdmin
+  class NIC < LinuxAdmin
+    attr_accessor :address
+
+    def initialize(args = {})
+      @address = args[:address]
+    end
+
+    def self.local
+      s = LinuxAdmin::DBus.service "org.freedesktop.NetworkManager"
+      o = s.object '/org/freedesktop/NetworkManager'
+      i = o.interface
+      i.devices().collect do |d|
+        p = d.interface("org.freedesktop.DBus.Properties")
+        address = inet_ntoa p.get('org.freedesktop.NetworkManager.Device', 'Ip4Address').last
+        NIC.new :address => address
+      end
+    end
+  end
+end

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -31,4 +31,5 @@ registration, updates, etc.
   spec.add_dependency "inifile",              "~> 2.0.2"
   spec.add_dependency "more_core_extensions"
   spec.add_dependency "nokogiri"
+  spec.add_dependency "ruby-dbus"
 end

--- a/spec/dbus_spec.rb
+++ b/spec/dbus_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe LinuxAdmin::DBus do
+  describe "#bus" do
+    it "returns dbus system bus"
+  end
+
+  describe "#service" do
+    it "returns service on dbus system bus"
+  end
+end
+
+describe LinuxAdmin::DBusService do
+  describe "#object" do
+    it "returns dbus object on service bus"
+  end
+end
+
+describe LinuxAdmin::DBusObject do
+  describe "#interface" do
+    it "returns dbus interface to object"
+  end
+end
+
+describe LinuxAdmin::DBusInterface do
+  describe "#[]" do
+    it "dispatches to dbus interface"
+  end
+
+  describe "#[]=" do
+    it "dispatches to dbus interface"
+  end
+end


### PR DESCRIPTION
Noticed a few of the things we want to pull into linux_admin is available via dbus. Whipped up this concept module of dbus integration into our library and am opening it up for comments. This could be made optional so that if dbus or the services aren't available, it could fall back to another approach.

Thoughts?
