### PR TITLE
Return an empty array of partitions on a non-zero rc from parted.

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -25,8 +25,11 @@ class LinuxAdmin
 
         # requires sudo
         out = run(cmd(:parted),
+                  :return_exitstatus => true,
                   :return_output => true,
                   :params => { nil => [@path, 'print'] })
+
+        return [] if out.kind_of?(Fixnum)
 
         out.each_line do |l|
           if l =~ /^ [0-9].*/

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -17,9 +17,17 @@ describe LinuxAdmin::Disk do
       disk = LinuxAdmin::Disk.new :path => '/dev/hda'
       disk.should_receive(:run).
         with(disk.cmd(:parted),
+             :return_exitstatus => true,
              :return_output => true,
              :params => { nil => ['/dev/hda', 'print'] }).and_return ""
       disk.partitions
+    end
+
+    it "returns [] on non-zero parted rc" do
+      disk = LinuxAdmin::Disk.new :path => '/dev/hda'
+      disk.stub(:exitstatus => 1)
+      disk.stub(:launch)
+      disk.partitions.should == []
     end
 
     it "sets partitons" do


### PR DESCRIPTION
In the event the disk label/partition table is missing, parted exits with the fixnum 1 from Linux Admin.
