### PR TITLE
Convert array items in the params to a String before shell escaping.

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -46,7 +46,7 @@ class LinuxAdmin
       return [] if params.blank?
       params.collect do |k, v|
         v = case v
-            when Array;    v.collect(&:shellescape)
+            when Array;    v.collect {|i| i.to_s.shellescape}
             when NilClass; v
             else           v.to_s.shellescape
             end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -47,6 +47,11 @@ describe LinuxAdmin::Common do
         subject.send(run_method, "true", :params => modified_params)
       end
 
+      it "sanitizes fixnum array params" do
+        subject.should_receive(:launch).once.with("true 1", {})
+        subject.send(run_method, "true", :params => { nil => [1]})
+      end
+
       it "as empty hash" do
         subject.should_receive(:launch).once.with("true", {})
         subject.send(run_method, "true", :params => {})


### PR DESCRIPTION
Fixes:

> disk = LinuxAdmin::Disk.local.first.create_partition("primary", disk.size.to_i)
> NoMethodError: undefined method `shellescape' for 0:Fixnum
