### PR TITLE
Add example confirming Pathnames can be used as param values.

### DIFF
--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -52,6 +52,12 @@ describe LinuxAdmin::Common do
         subject.send(run_method, "true", :params => { nil => [1]})
       end
 
+      it "sanitizes Pathname params" do
+        require 'pathname'
+        subject.should_receive(:launch).once.with("true /usr/bin/ruby", {})
+        subject.send(run_method, "true", :params => { nil => [Pathname.new("/usr/bin/ruby")]})
+      end
+
       it "as empty hash" do
         subject.should_receive(:launch).once.with("true", {})
         subject.send(run_method, "true", :params => {})


### PR DESCRIPTION
Fixed by 6a755131a79c41166c4834d89fb16c83c240c687
Fixes #22
