### PR TITLE
Fix Pathname support

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -56,13 +56,13 @@ class LinuxAdmin
 
     def assemble_params(sanitized_params)
       sanitized_params.collect do |pair|
-        pair_joiner = pair.first.try(:end_with?, "=") ? "" : " "
+        pair_joiner = pair.first.to_s.end_with?("=") ? "" : " "
         pair.flatten.compact.join(pair_joiner)
       end.join(" ")
     end
 
     def build_cmd(cmd, params = nil)
-      return cmd if params.blank?
+      return cmd.to_s if params.blank?
       "#{cmd} #{assemble_params(sanitize(params))}"
     end
 

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -37,7 +37,7 @@ describe LinuxAdmin::Common do
   end
 
   shared_examples_for "run" do
-    context "with params" do
+    context "paramater and command handling" do
       before do
         subject.stub(:exitstatus => 0)
       end
@@ -49,13 +49,19 @@ describe LinuxAdmin::Common do
 
       it "sanitizes fixnum array params" do
         subject.should_receive(:launch).once.with("true 1", {})
-        subject.send(run_method, "true", :params => { nil => [1]})
+        subject.send(run_method, "true", :params => {nil => [1]})
       end
 
-      it "sanitizes Pathname params" do
+      it "sanitizes Pathname option value" do
         require 'pathname'
         subject.should_receive(:launch).once.with("true /usr/bin/ruby", {})
         subject.send(run_method, "true", :params => {nil => [Pathname.new("/usr/bin/ruby")]})
+      end
+
+      it "sanitizes Pathname option" do
+        require 'pathname'
+        subject.should_receive(:launch).once.with("true /usr/bin/ruby", {})
+        subject.send(run_method, "true", :params => {Pathname.new("/usr/bin/ruby") => nil})
       end
 
       it "as empty hash" do
@@ -73,6 +79,16 @@ describe LinuxAdmin::Common do
         subject.stub(:launch)
         subject.send(run_method, "true", :params => params)
         expect(orig_params).to eq(params)
+      end
+
+      it "Pathname command" do
+        subject.should_receive(:launch).once.with("/usr/bin/ruby", {})
+        subject.send(run_method, Pathname.new("/usr/bin/ruby"), {})
+      end
+
+      it "Pathname command with params" do
+        subject.should_receive(:launch).once.with("/usr/bin/ruby -v", {})
+        subject.send(run_method, Pathname.new("/usr/bin/ruby"), :params => {"-v" => nil})
       end
 
       it "supports spawn's chdir option" do


### PR DESCRIPTION
Opened as a followup to #41 since Pathnames were not supported in commands with no parameters and when used a parameter options.
