### PR TITLE
Requiring 'linux_admin' failed because 'pathname' had not been required

### DIFF
--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -3,6 +3,8 @@
 # Copyright (C) 2013 Red Hat Inc.
 # Licensed under the MIT License
 
+require 'pathname'
+
 class LinuxAdmin
   class LogicalVolume < Volume
     DEVICE_PATH  = Pathname.new('/dev/')


### PR DESCRIPTION
Was raising: NameError: uninitialized constant LinuxAdmin::LogicalVolume::Pathname
