### PR TITLE
Support a Pathname lv 'name' by converting it to a new String.

### DIFF
--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -44,8 +44,9 @@ class LinuxAdmin
     def initialize(args = {})
       @volume_group = args[:volume_group]
       @sectors      = args[:sectors]
-      self.path     = args[:name]
-      self.name     = args[:name]
+      provided_name = args[:name].to_s
+      self.path     = provided_name
+      self.name     = provided_name
     end
 
     def extend_with(vg)

--- a/spec/logical_volume_spec.rb
+++ b/spec/logical_volume_spec.rb
@@ -104,6 +104,17 @@ eos
       end
     end
 
+    context "path is specified as Pathname" do
+      it "sets name" do
+        require 'pathname'
+        LinuxAdmin::VolumeGroup.stub(:run! => double(:output => ""))
+        described_class.stub(:run! => double(:output => ""))
+        lv = described_class.create Pathname.new("/dev/#{@vg.name}/lv"), @vg, 256.gigabytes
+        lv.name.should == "lv"
+        lv.path.should == "/dev/vg/lv"
+      end
+    end
+
     it "adds logical volume to local registry" do
       LinuxAdmin::VolumeGroup.stub(:run! => double(:output => ""))
       described_class.stub(:run! => double(:output => ""))


### PR DESCRIPTION
Even though we don't use the added features of Pathnames here, we should accept them and convert to a new String.

Later, we can perhaps clean up some of the String processing by fully supporting pathnames and in fact, convert any provided string paths to pathnames.
