### PR TITLE
raise an error when a command is not defined

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -3,7 +3,7 @@ require 'awesome_spawn'
 class LinuxAdmin
   module Common
     def cmd(cmd)
-      Distro.local.class::COMMANDS[cmd]
+      Distro.local.commands[cmd] || raise(ArgumentError, "command #{cmd} not defined for #{Distro.local.id}")
     end
 
     def run(cmd, options = {})

--- a/lib/linux_admin/distro.rb
+++ b/lib/linux_admin/distro.rb
@@ -5,10 +5,11 @@
 
 class LinuxAdmin
   class Distro < LinuxAdmin
-    attr_accessor :id
+    attr_accessor :id, :commands
 
-    def initialize(id)
+    def initialize(id, commands)
       @id = id
+      @commands = commands
     end
 
     def self.local
@@ -50,42 +51,39 @@ class LinuxAdmin
     end
 
     class Generic < Distro
-      COMMANDS = {}
-
       def initialize
-        @id = :generic
+        super(:generic, {})
       end
     end
 
     class RedHat < Distro
-      COMMANDS = {:service   => '/sbin/service',
-                  :chkconfig => '/sbin/chkconfig',
-                  :parted    => '/sbin/parted',
-                  :mount     => '/bin/mount',
-                  :umount    => '/bin/umount',
-                  :shutdown  => '/sbin/shutdown',
-                  :mke2fs    => '/sbin/mke2fs',
-                  :fdisk     => '/sbin/fdisk',
-                  :dd        => '/bin/dd',
-                  :vgdisplay => '/sbin/vgdisplay',
-                  :pvdisplay => '/sbin/pvdisplay',
-                  :lvdisplay => '/sbin/lvdisplay',
-                  :lvextend  => '/sbin/lvextend',
-                  :vgextend  => '/sbin/vgextend',
-                  :lvcreate  => '/sbin/lvcreate',
-                  :pvcreate  => '/sbin/pvcreate',
-                  :vgcreate  => '/sbin/vgcreate'}
-
       def initialize
-        @id = :redhat
+        super(
+          :redhat,
+          :service   => '/sbin/service',
+          :chkconfig => '/sbin/chkconfig',
+          :parted    => '/sbin/parted',
+          :mount     => '/bin/mount',
+          :umount    => '/bin/umount',
+          :shutdown  => '/sbin/shutdown',
+          :mke2fs    => '/sbin/mke2fs',
+          :fdisk     => '/sbin/fdisk',
+          :dd        => '/bin/dd',
+          :vgdisplay => '/sbin/vgdisplay',
+          :pvdisplay => '/sbin/pvdisplay',
+          :lvdisplay => '/sbin/lvdisplay',
+          :lvextend  => '/sbin/lvextend',
+          :vgextend  => '/sbin/vgextend',
+          :lvcreate  => '/sbin/lvcreate',
+          :pvcreate  => '/sbin/pvcreate',
+          :vgcreate  => '/sbin/vgcreate'
+        )
       end
     end
 
     class Ubuntu < Distro
-      COMMANDS = {}
-
       def initialize
-        @id = :ubuntu
+        super(:ubuntu, {})
       end
     end
   end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -15,10 +15,12 @@ describe LinuxAdmin::Common do
 
   context "#cmd" do
     it "looks up local command from id" do
-      d = double(LinuxAdmin::Distro)
-      d.class::COMMANDS = {:sh => '/bin/sh'}
-      LinuxAdmin::Distro.should_receive(:local).and_return(d)
+      stub_distro(:sh => '/bin/sh')
       subject.cmd(:sh).should == '/bin/sh'
+    end
+
+    it "complains when command not found" do
+      expect { subject.cmd(:notfound) }.to raise_error
     end
   end
 

--- a/spec/distro_spec.rb
+++ b/spec/distro_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe LinuxAdmin::Distro do
   describe "#local" do
+    before do
+      LinuxAdmin::Distro.unstub(:local)
+    end
+
     after(:each) do
       # distro generates a local copy, reset after each run
       LinuxAdmin::Distro.instance_variable_set(:@local, nil)

--- a/spec/logical_volume_spec.rb
+++ b/spec/logical_volume_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 describe LinuxAdmin::LogicalVolume do
   before(:each) do
-    LinuxAdmin::Distro.stub(:local => LinuxAdmin::Distros::Test.new)
-
     @logical_volumes = <<eos
   /dev/vg_foobar/lv_swap:vg_foobar:3:1:-1:2:4128768:63:-1:0:-1:253:0
   /dev/vg_foobar/lv_root:vg_foobar:3:1:-1:1:19988480:305:-1:0:-1:253:1

--- a/spec/physical_volume_spec.rb
+++ b/spec/physical_volume_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 describe LinuxAdmin::PhysicalVolume do
   before(:each) do
-    LinuxAdmin::Distro.stub(:local => LinuxAdmin::Distros::Test.new)
-
     @physical_volumes = <<eos
   /dev/vda2:vg_foobar:24139776:-1:8:8:-1:32768:368:0:368:pxR32D-YkC2-PfHe-zOwb-eaGD-9Ar0-mAOl9u
 eos

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe LinuxAdmin::Service do
   before(:each) do
-    # stub distro.local to return test distro for command lookup
-    LinuxAdmin::Distro.stub(:local).
-                       and_return(LinuxAdmin::Distros::Test.new)
-
     @service = LinuxAdmin::Service.new 'foo'
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
 
   config.before do
     Kernel.stub(:spawn).and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")
+    # by default, have it say it is running Red Hat linux
+    stub_distro
   end
 
   config.after do
@@ -32,6 +34,11 @@ end
 
 require 'linux_admin'
 
+def stub_distro(distro = LinuxAdmin::Distros.redhat)
+  # simply alias test distro to redhat distro for time being
+  distro = LinuxAdmin::Distro.new(:testing, distro) if distro.is_a?(Hash)
+  LinuxAdmin::Distro.stub(:local => distro)
+end
 
 def data_file_path(to)
   File.expand_path(to, File.join(File.dirname(__FILE__), "data"))
@@ -43,11 +50,4 @@ end
 
 def clear_caches
   LinuxAdmin::RegistrationSystem.instance_variable_set(:@registration_type, nil)
-end
-
-class LinuxAdmin
-  module Distros
-    # simply alias test distro to redhat distro for time being
-    Distros::Test = Distros::RedHat
-  end
 end

--- a/spec/volume_group_spec.rb
+++ b/spec/volume_group_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 describe LinuxAdmin::VolumeGroup do
   before(:each) do
-    LinuxAdmin::Distro.stub(:local => LinuxAdmin::Distros::Test.new)
-
     @groups = <<eos
   vg_foobar:r/w:772:-1:0:2:2:-1:0:1:1:12058624:32768:368:368:0:tILZUF-IspH-H90I-pT5j-vVFl-b76L-zWx3CW
 eos


### PR DESCRIPTION
When the os can't be found, we tend to get '--arg' is not a valid command.

This raises an exception to say that the command is not found.

issue: not sure the best way to communicate this with the calling app.
