### PR TITLE
service start_and_detach

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -13,5 +13,13 @@ class LinuxAdmin
     def run!(cmd, options = {})
       AwesomeSpawn.run!(cmd, options)
     end
+
+    # NOTE: only currently supports options: :params => []
+    def detach(cmd, options = {})
+      params = Array(options[:params])
+      Process.detach(Kernel.spawn(
+        "#{cmd} #{params.join(" ")}",
+        [:out, :err] => ["/dev/null", "w"]))
+    end
   end
 end

--- a/lib/linux_admin/service.rb
+++ b/lib/linux_admin/service.rb
@@ -38,6 +38,12 @@ class LinuxAdmin
       self
     end
 
+    def start_and_detach
+      detach(cmd(:service),
+             :params => [id, "start"])
+      self
+    end
+
     def stop
       run!(cmd(:service),
           :params => { nil => [id, "stop"] })


### PR DESCRIPTION
I saw a comment requesting this feature.
1. did not looke like awesome spawn supported detach. (unless there is a different phrase to grep for)
2. not sure how to test
3. it would be nice to support parameters the same way that awesome spawn does, but the hash variety seemed like overkill.

looking for guidance.
