### PR TITLE
Require active_support before core_ext to fix uninitialized constant

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -1,4 +1,5 @@
 require 'more_core_extensions/all'
+require 'active_support'
 require 'active_support/core_ext'
 
 require 'linux_admin/registration_system'


### PR DESCRIPTION
Fixes travis error with linux_admin:
https://travis-ci.org/ManageIQ/linux_admin/builds/29519678

This is a known issue with activesupport and travis:
https://github.com/rails/rails/issues/14664

See also:
https://github.com/ManageIQ/polisher/commit/c899d500502a57582a906dfa20cc6cf343c09265
