### PR TITLE
Readd Package abstract class that was removed in #96

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -6,6 +6,7 @@ require 'linux_admin/registration_system'
 
 require 'linux_admin/common'
 require 'linux_admin/exceptions'
+require 'linux_admin/package'
 require 'linux_admin/rpm'
 require 'linux_admin/deb'
 require 'linux_admin/version'

--- a/lib/linux_admin/deb.rb
+++ b/lib/linux_admin/deb.rb
@@ -4,7 +4,7 @@
 # Licensed under the MIT License
 
 class LinuxAdmin
-  class Deb
+  class Deb < Package
     APT_CACHE_CMD = '/usr/bin/apt-cache'
 
     def self.from_line(apt_cache_line, in_description=false)

--- a/lib/linux_admin/package.rb
+++ b/lib/linux_admin/package.rb
@@ -1,0 +1,4 @@
+class LinuxAdmin
+  class Package < LinuxAdmin
+  end
+end

--- a/lib/linux_admin/rpm.rb
+++ b/lib/linux_admin/rpm.rb
@@ -1,5 +1,5 @@
 class LinuxAdmin
-  class Rpm
+  class Rpm < Package
     def self.rpm_cmd
       Distros.local.command(:rpm)
     end


### PR DESCRIPTION
Removed in #96, Specifically commit c99c63b

Previously Rpm < Package < LinuxAdmin, and LinuxAdmin is where
the .run method comes from.  By removing Package, Rpm broke
by not having access to .run.  This readds the class to fix
that issue.
