### PR TITLE
Use bytes to determine disk size

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -70,7 +70,7 @@ module LinuxAdmin
         out = run!(cmd(:fdisk), :params => {"-l" => nil}).output
         out.each_line { |l|
           if l =~ /Disk #{path}: .*B, (\d+) bytes/
-            size = $1.to_f
+            size = $1.to_i
             break
           end
         }

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -68,12 +68,12 @@ module LinuxAdmin
       @size ||= begin
         size = nil
         out = run!(cmd(:fdisk), :params => {"-l" => nil}).output
-        out.each_line { |l|
-          if l =~ /Disk #{path}: .*B, (\d+) bytes/
-            size = $1.to_i
+        out.each_line do |l|
+          /Disk #{path}: .*B, (\d+) bytes/.match(l) do |m|
+            size = m[1].to_i
             break
           end
-        }
+        end
         size
       end
     end

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -69,8 +69,8 @@ module LinuxAdmin
         size = nil
         out = run!(cmd(:fdisk), :params => {"-l" => nil}).output
         out.each_line { |l|
-          if l =~ /Disk #{path}: ([0-9\.]*) ([KMG])B.*/
-            size = str_to_bytes($1, $2)
+          if l =~ /Disk #{path}: .*B, (\d+) bytes/
+            size = $1.to_f
             break
           end
         }

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -37,7 +37,7 @@ eos
 
       disk = LinuxAdmin::Disk.new :path => '/dev/hda'
       allow(disk).to receive(:run!).and_return(double(:output => fdisk))
-      expect(disk.size).to eq(500107862016)
+      expect(disk.size).to eq(500_107_862_016)
     end
   end
 

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -37,7 +37,7 @@ eos
 
       disk = LinuxAdmin::Disk.new :path => '/dev/hda'
       allow(disk).to receive(:run!).and_return(double(:output => fdisk))
-      expect(disk.size).to eq(500.1.gigabytes)
+      expect(disk.size).to eq(500107862016)
     end
   end
 


### PR DESCRIPTION
Changed Disk#size to parse the bytes value directly from the fdisk(8) output.
    
Parsing the converted value was causing an issue as fdisk was using SI units
and the rails methods were expecting binary units.
For example, 5MB was being converted to 5 * 1024 * 1024 bytes by rails
when fdisk intended the value to be 5 * 1000 * 1000 bytes.
This change avoids the confusion by parsing the bytes value directly.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1096331