### PR TITLE
Fix NameError on IPAddr when running tests locally

### DIFF
--- a/lib/linux_admin/ip_address.rb
+++ b/lib/linux_admin/ip_address.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module LinuxAdmin
   class IpAddress
     include Common


### PR DESCRIPTION
Introduced in commit: 17c5d4434971e, PR #124

Not quite sure why the test suite didn't fail on travis but it was failing for me locally.