### PR TITLE
Added error class to rspec raise_error expectations

### DIFF
--- a/spec/scap_spec.rb
+++ b/spec/scap_spec.rb
@@ -6,7 +6,7 @@ describe LinuxAdmin::Scap do
       allow(described_class).to receive(:openscap_available?).and_return(true)
       allow(described_class).to receive(:ssg_available?).and_return(true)
       allow(scap).to receive(:lockdown_profile)
-      expect { scap.lockdown("value1" => true) }.to raise_error
+      expect { scap.lockdown("value1" => true) }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/yum_spec.rb
+++ b/spec/yum_spec.rb
@@ -82,7 +82,7 @@ describe LinuxAdmin::Yum do
 
     it "other exit code" do
       allow(described_class).to receive_messages(:run => double(:exit_status => 255))
-      expect { described_class.updates_available? }.to raise_error
+      expect { described_class.updates_available? }.to raise_error(RuntimeError)
     end
 
     it "other error" do


### PR DESCRIPTION
This removes warnings of the form:

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false 
positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or 
`ArgumentError`, potentially allowing the expectation to pass without even executing the method you 
are intending to call. Instead consider providing a specific error class or message. This message can 
be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = 
false`.
```