### PR TITLE
Move command out of distros

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -2,12 +2,14 @@ require 'awesome_spawn'
 
 module LinuxAdmin
   module Common
-    def cmd(cmd)
-      Distros.local.command(cmd)
+    BIN_DIRS = %w(/bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin)
+
+    def cmd(name)
+      BIN_DIRS.collect { |dir| "#{dir}/#{name}" }.detect { |cmd| File.exist?(cmd) }
     end
 
-    def cmd?(cmd)
-      Distros.local.command?(cmd)
+    def cmd?(name)
+      !cmd(name).nil?
     end
 
     def run(cmd, options = {})

--- a/lib/linux_admin/distro.rb
+++ b/lib/linux_admin/distro.rb
@@ -38,7 +38,6 @@ module LinuxAdmin
 
       def initialize(id, release_file = nil, etc_issue_keywords = [], info_class = nil)
         @id                 = id
-        @path               = %w(/sbin /bin /usr/bin /usr/sbin)
         @release_file       = release_file
         @etc_issue_keywords = etc_issue_keywords
         @info_class         = info_class
@@ -54,14 +53,6 @@ module LinuxAdmin
 
       def detected_by_etc_release?
         release_file && File.exist?(release_file)
-      end
-
-      def command(name)
-        @path.collect { |dir| "#{dir}/#{name}" }.detect { |cmd| File.exist?(cmd) }
-      end
-
-      def command?(name)
-        !!command(name)
       end
 
       def info(pkg)

--- a/lib/linux_admin/rpm.rb
+++ b/lib/linux_admin/rpm.rb
@@ -3,7 +3,7 @@ module LinuxAdmin
     extend Logging
 
     def self.rpm_cmd
-      Distros.local.command(:rpm)
+      cmd(:rpm)
     end
 
     def self.list_installed

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -1,19 +1,37 @@
 describe LinuxAdmin::Common do
   subject { Class.new { include LinuxAdmin::Common }.new }
 
-  context "#cmd" do
+  describe "#cmd" do
     it "looks up local command from id" do
       expect(subject.cmd(:dd)).to match(/bin\/dd/)
     end
+
+    it "returns nil when it can't find the command" do
+      expect(subject.cmd(:kasgbdlcvjhals)).to be_nil
+    end
   end
 
-  it "#run" do
-    expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
-    subject.run("echo", nil => "test")
+  describe "#cmd?" do
+    it "returns true when the command exists" do
+      expect(subject.cmd?(:dd)).to be true
+    end
+
+    it "returns false when the command doesn't exist" do
+      expect(subject.cmd?(:kasgbdlcvjhals)).to be false
+    end
   end
 
-  it "#run!" do
-    expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
-    subject.run!("echo", nil => "test")
+  describe "#run" do
+    it "runs a command with AwesomeSpawn.run" do
+      expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
+      subject.run("echo", nil => "test")
+    end
+  end
+
+  describe "#run!" do
+    it "runs a command with AwesomeSpawn.run!" do
+      expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
+      subject.run!("echo", nil => "test")
+    end
   end
 end


### PR DESCRIPTION
This method was just searching a set of predefined paths to binary files for the one it was asked for. That has nothing to do with what distro we are on.