### PR TITLE
Allow NetworkInterface creation without a config file

### DIFF
--- a/lib/linux_admin/exceptions.rb
+++ b/lib/linux_admin/exceptions.rb
@@ -6,4 +6,6 @@ module LinuxAdmin
   end
 
   class NetworkInterfaceError < AwesomeSpawn::CommandResultError; end
+
+  class MissingConfigurationFileError < StandardError; end
 end

--- a/lib/linux_admin/network_interface.rb
+++ b/lib/linux_admin/network_interface.rb
@@ -25,6 +25,8 @@ module LinuxAdmin
     # Creates an instance of the correct NetworkInterface subclass for the local distro
     def self.new(*args)
       self == LinuxAdmin::NetworkInterface ? dist_class.new(*args) : super
+    rescue MissingConfigurationFileError
+      NetworkInterfaceGeneric.new(*args)
     end
 
     # @return [String] the interface for networking operations

--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -10,8 +10,9 @@ module LinuxAdmin
 
     # @param interface [String] Name of the network interface to manage
     def initialize(interface)
+      @interface_file = Pathname.new(IFACE_DIR).join("ifcfg-#{interface}")
+      raise MissingConfigurationFileError unless File.exist?(@interface_file)
       super
-      @interface_file = Pathname.new(IFACE_DIR).join("ifcfg-#{@interface}")
       parse_conf
     end
 

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -34,12 +34,14 @@ EOF
   end
 
   subject(:dhcp_interface) do
+    allow(File).to receive(:exist?).and_return(true)
     stub_foreach_to_string(IFCFG_FILE_DHCP)
     allow(AwesomeSpawn).to receive(:run!).twice.and_return(result("", 0))
     described_class.new(DEVICE_NAME)
   end
 
   subject(:static_interface) do
+    allow(File).to receive(:exist?).and_return(true)
     stub_foreach_to_string(IFCFG_FILE_STATIC)
     allow(AwesomeSpawn).to receive(:run!).twice.and_return(result("", 0))
     described_class.new(DEVICE_NAME)

--- a/spec/network_interface_spec.rb
+++ b/spec/network_interface_spec.rb
@@ -1,10 +1,19 @@
 describe LinuxAdmin::NetworkInterface do
   context "on redhat systems" do
-    subject do
+    subject(:subj_success) do
       allow_any_instance_of(described_class).to receive(:ip_show).and_return(nil)
       allow(LinuxAdmin::Distros).to receive(:local).and_return(LinuxAdmin::Distros.rhel)
       described_class.dist_class(true)
+      allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:foreach).and_return("")
+      described_class.new("eth0")
+    end
+
+    subject(:subj_failure) do
+      allow_any_instance_of(described_class).to receive(:ip_show).and_return(nil)
+      allow(LinuxAdmin::Distros).to receive(:local).and_return(LinuxAdmin::Distros.rhel)
+      described_class.dist_class(true)
+      allow(File).to receive(:exist?).and_return(false)
       described_class.new("eth0")
     end
 
@@ -17,7 +26,11 @@ describe LinuxAdmin::NetworkInterface do
 
     describe ".new" do
       it "creates a NetworkInterfaceRH instance" do
-        expect(subject).to be_an_instance_of(LinuxAdmin::NetworkInterfaceRH)
+        expect(subj_success).to be_an_instance_of(LinuxAdmin::NetworkInterfaceRH)
+      end
+
+      it "creates a NetworkInterfaceGeneric instance if the config file does not exist" do
+        expect(subj_failure).to be_an_instance_of(LinuxAdmin::NetworkInterfaceGeneric)
       end
     end
   end


### PR DESCRIPTION
This will allow a user on a Red Hat system to use the "getter" methods defined in `network_interface.rb` even if they don't have a config file corresponding to the given interface name.

To do this we instantiate a `NetworkInterfaceGeneric` object if the file doesn't exist rather than a `NetworkInterfaceRH` instance.

@abonas @bdunne @Fryguy 

Fixes #139