### PR TITLE
Dont fail when only IPv6 addresses are returned by `ip addr show`

### DIFF
--- a/lib/linux_admin/network_interface.rb
+++ b/lib/linux_admin/network_interface.rb
@@ -158,7 +158,7 @@ module LinuxAdmin
     #
     # @param ip_output [String] The command output
     def parse_ip4(ip_output)
-      cidr_ip = parse_ip_output(ip_output, /inet/, 1)
+      cidr_ip = parse_ip_output(ip_output, /inet /, 1)
       return unless cidr_ip
 
       @network_conf[:address] = cidr_ip.split('/')[0]


### PR DESCRIPTION
Previously the regex in `NetworkInterface#parse_ip4` would also match ipv6 addresses.
This would cause an issue when only ipv6 addresses were returned by the `ip addr show` command.
This problem was masked by the fact that ipv4 addresses are returned first in the output and `detect` returns the first matching line.

@bdunne 