### PR TITLE
Add chrony conf class

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -32,6 +32,7 @@ require 'linux_admin/time_date'
 require 'linux_admin/ip_address'
 require 'linux_admin/dns'
 require 'linux_admin/network_interface'
+require 'linux_admin/chrony'
 
 module LinuxAdmin
   extend Common

--- a/lib/linux_admin/chrony.rb
+++ b/lib/linux_admin/chrony.rb
@@ -1,0 +1,21 @@
+module LinuxAdmin
+  class Chrony
+    def initialize(conf = "/etc/chrony.conf")
+      raise MissingConfigurationFileError, "#{conf} does not exist" unless File.exist?(conf)
+      @conf = conf
+    end
+
+    def clear_servers
+      data = File.read(@conf)
+      data.gsub!(/^server\s+.+\n/, "")
+      File.write(@conf, data)
+    end
+
+    def add_servers(*servers)
+      data = File.read(@conf)
+      data << "\n" unless data.end_with?("\n")
+      servers.each { |s| data << "server #{s}\n" }
+      File.write(@conf, data)
+    end
+  end
+end

--- a/spec/chrony_spec.rb
+++ b/spec/chrony_spec.rb
@@ -1,0 +1,41 @@
+describe LinuxAdmin::Chrony do
+  CHRONY_CONF = <<-EOF
+# commented server baz.example.net
+server foo.example.net
+server bar.example.net iburst
+driftfile /var/lib/chrony/drift
+makestep 10 3
+rtcsync
+EOF
+
+  subject do
+    allow(File).to receive(:exist?).and_return(true)
+    described_class.new
+  end
+
+  describe ".new" do
+    it "raises when the given config file doesn't exist" do
+      expect { described_class.new("nonsense/file") }.to raise_error(LinuxAdmin::MissingConfigurationFileError)
+    end
+  end
+
+  describe "#clear_servers" do
+    it "removes all the server lines from the conf file" do
+      allow(File).to receive(:read).and_return(CHRONY_CONF.dup)
+      expect(File).to receive(:write) do |_file, contents|
+        expect(contents).to eq "# commented server baz.example.net\ndriftfile /var/lib/chrony/drift\nmakestep 10 3\nrtcsync\n"
+      end
+      subject.clear_servers
+    end
+  end
+
+  describe "#add_servers" do
+    it "adds server lines to the conf file" do
+      allow(File).to receive(:read).and_return(CHRONY_CONF.dup)
+      expect(File).to receive(:write) do |_file, contents|
+        expect(contents).to eq(CHRONY_CONF + "server baz.example.net\nserver foo.bar.example.com\n")
+      end
+      subject.add_servers("baz.example.net", "foo.bar.example.com")
+    end
+  end
+end


### PR DESCRIPTION
Added a class for managing the chronyd configuration file.

Currently only includes methods to add servers and remove servers.