### PR TITLE
Made Common its own class rather than a module

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -36,8 +36,6 @@ require 'linux_admin/network_interface'
 require 'linux_admin/chrony'
 
 module LinuxAdmin
-  extend Common
-
   class << self
     attr_writer :logger
   end

--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -6,20 +6,20 @@ module LinuxAdmin
 
     BIN_DIRS = %w(/bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin)
 
-    def cmd(name)
+    def self.cmd(name)
       BIN_DIRS.collect { |dir| "#{dir}/#{name}" }.detect { |cmd| File.exist?(cmd) }
     end
 
-    def cmd?(name)
+    def self.cmd?(name)
       !cmd(name).nil?
     end
 
-    def run(cmd, options = {})
+    def self.run(cmd, options = {})
       AwesomeSpawn.logger ||= logger
       AwesomeSpawn.run(cmd, options)
     end
 
-    def run!(cmd, options = {})
+    def self.run!(cmd, options = {})
       AwesomeSpawn.logger ||= logger
       AwesomeSpawn.run!(cmd, options)
     end

--- a/lib/linux_admin/deb.rb
+++ b/lib/linux_admin/deb.rb
@@ -27,7 +27,7 @@ module LinuxAdmin
     end
 
     def self.info(pkg)
-      self.from_string(run!(APT_CACHE_CMD, :params => ["show", pkg]).output)
+      from_string(Common.run!(APT_CACHE_CMD, :params => ["show", pkg]).output)
     end
   end
 end

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -2,8 +2,6 @@ require 'linux_admin/partition'
 
 module LinuxAdmin
   class Disk
-    include Common
-
     PARTED_FIELDS =
       [:id, :start_sector, :end_sector,
        :size, :partition_type, :fs_type]
@@ -62,7 +60,7 @@ module LinuxAdmin
     def size
       @size ||= begin
         size = nil
-        out = run!(cmd(:fdisk), :params => {"-l" => nil}).output
+        out = Common.run!(Common.cmd(:fdisk), :params => {"-l" => nil}).output
         out.each_line do |l|
           /Disk #{path}: .*B, (\d+) bytes/.match(l) do |m|
             size = m[1].to_i
@@ -86,7 +84,7 @@ module LinuxAdmin
       # TODO: Should this really catch non-zero RC, set output to the default "" and silently return [] ?
       #   If so, should other calls to parted also do the same?
       # requires sudo
-      out = run(cmd(:parted),
+      out = Common.run(Common.cmd(:parted),
                 :params => { nil => parted_options_array('print') }).output
       split = []
       out.each_line do |l|
@@ -121,11 +119,11 @@ module LinuxAdmin
     public
 
     def create_partition_table(type = "msdos")
-      run!(cmd(:parted), :params => { nil => parted_options_array("mklabel", type)})
+      Common.run!(Common.cmd(:parted), :params => {nil => parted_options_array("mklabel", type)})
     end
 
     def has_partition_table?
-      result = run(cmd(:parted), :params => { nil => parted_options_array("print")})
+      result = Common.run(Common.cmd(:parted), :params => {nil => parted_options_array("print")})
 
       result_indicates_partition_table?(result)
     end
@@ -150,7 +148,7 @@ module LinuxAdmin
 
       id = partitions.empty? ? 1 : (partitions.last.id + 1)
       options = parted_options_array('mkpart', '-a', 'opt', partition_type, start, finish)
-      run!(cmd(:parted), :params => { nil => options})
+      Common.run!(Common.cmd(:parted), :params => {nil => options})
 
       partition = Partition.new(:disk           => self,
                                 :id             => id,
@@ -174,7 +172,7 @@ module LinuxAdmin
       @partitions = []
 
       # clear partition table
-      run!(cmd(:dd),
+      Common.run!(Common.cmd(:dd),
           :params => { 'if=' => '/dev/zero', 'of=' => @path,
                        'bs=' => 512, 'count=' => 1})
 

--- a/lib/linux_admin/hosts.rb
+++ b/lib/linux_admin/hosts.rb
@@ -1,7 +1,5 @@
 module LinuxAdmin
   class Hosts
-    include Common
-
     attr_accessor :filename
     attr_accessor :raw_lines
     attr_accessor :parsed_file
@@ -33,16 +31,16 @@ module LinuxAdmin
     end
 
     def hostname=(name)
-      if cmd?("hostnamectl")
-        run!(cmd('hostnamectl'), :params => ['set-hostname', name])
+      if Common.cmd?("hostnamectl")
+        Common.run!(Common.cmd('hostnamectl'), :params => ['set-hostname', name])
       else
         File.write("/etc/hostname", name)
-        run!(cmd('hostname'), :params => {:file => "/etc/hostname"})
+        Common.run!(Common.cmd('hostname'), :params => {:file => "/etc/hostname"})
       end
     end
 
     def hostname
-      result = run(cmd("hostname"))
+      result = Common.run(Common.cmd("hostname"))
       result.success? ? result.output.strip : nil
     end
 

--- a/lib/linux_admin/ip_address.rb
+++ b/lib/linux_admin/ip_address.rb
@@ -2,8 +2,6 @@ require 'ipaddr'
 
 module LinuxAdmin
   class IpAddress
-    include Common
-
     def address
       address_list.detect { |ip| IPAddr.new(ip).ipv4? }
     end
@@ -13,21 +11,21 @@ module LinuxAdmin
     end
 
     def mac_address(interface)
-      result = run(cmd("ip"), :params => ["addr", "show", interface])
+      result = Common.run(Common.cmd("ip"), :params => ["addr", "show", interface])
       return nil if result.failure?
 
       parse_output(result.output, %r{link/ether}, 1)
     end
 
     def netmask(interface)
-      result = run(cmd("ifconfig"), :params => [interface])
+      result = Common.run(Common.cmd("ifconfig"), :params => [interface])
       return nil if result.failure?
 
       parse_output(result.output, /netmask/, 3)
     end
 
     def gateway
-      result = run(cmd("ip"), :params => ["route"])
+      result = Common.run(Common.cmd("ip"), :params => ["route"])
       return nil if result.failure?
 
       parse_output(result.output, /^default/, 2)
@@ -45,7 +43,7 @@ module LinuxAdmin
       # Added retry to account for slow DHCP not assigning an IP quickly at boot; specifically:
       # https://github.com/ManageIQ/manageiq-appliance/commit/160d8ccbfbfd617bdb5445e56cdab66b9323b15b
       5.times do
-        result = run(cmd("hostname"), :params => ["-I"])
+        result = Common.run(Common.cmd("hostname"), :params => ["-I"])
         break if result.success?
       end
 

--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -49,7 +49,7 @@ module LinuxAdmin
     end
 
     def extend_with(vg)
-      run!(cmd(:lvextend),
+      Common.run!(Common.cmd(:lvextend),
           :params => [self.name, vg.name])
       self
     end
@@ -81,7 +81,7 @@ module LinuxAdmin
         size = value
         params.merge!({'-L' => bytes_to_string(size)})
       end
-      run!(cmd(:lvcreate), :params => params)
+      Common.run!(Common.cmd(:lvcreate), :params => params)
 
       lv = LogicalVolume.new(:name => name,
                              :volume_group => vg,
@@ -92,7 +92,7 @@ module LinuxAdmin
 
     def self.scan
       @lvs ||= begin
-        scan_volumes(cmd(:lvdisplay)) do |fields, vg|
+        scan_volumes(Common.cmd(:lvdisplay)) do |fields, vg|
           LogicalVolume.new(:name         => fields[0],
                             :volume_group => vg,
                             :sectors      => fields[6].to_i)

--- a/lib/linux_admin/mountable.rb
+++ b/lib/linux_admin/mountable.rb
@@ -2,13 +2,10 @@ module LinuxAdmin
   module Mountable
     attr_accessor :fs_type
     attr_accessor :mount_point
-    include Common
 
     module ClassMethods
-      include Common
-
       def mount_point_exists?(mount_point)
-        result = run!(cmd(:mount))
+        result = Common.run!(Common.cmd(:mount))
         result.output.split("\n").any? { |line| line.split[2] == mount_point }
       end
 
@@ -22,8 +19,8 @@ module LinuxAdmin
     end
 
     def format_to(filesystem)
-      run!(cmd(:mke2fs),
-          :params => { '-t' => filesystem, nil => self.path})
+      Common.run!(Common.cmd(:mke2fs),
+                  :params => {'-t' => filesystem, nil => path})
       @fs_type = filesystem
     end
 
@@ -34,12 +31,12 @@ module LinuxAdmin
         raise ArgumentError, "disk already mounted at #{mount_point}"
       end
 
-      run!(cmd(:mount), :params => { nil => [self.path, mount_point] })
+      Common.run!(Common.cmd(:mount), :params => {nil => [path, mount_point]})
       @mount_point = mount_point
     end
 
     def umount
-      run!(cmd(:umount), :params => { nil => [@mount_point] })
+      Common.run!(Common.cmd(:umount), :params => {nil => [@mount_point]})
     end
   end
 end

--- a/lib/linux_admin/network_interface.rb
+++ b/lib/linux_admin/network_interface.rb
@@ -2,8 +2,6 @@ require 'ipaddr'
 
 module LinuxAdmin
   class NetworkInterface
-    include Common
-
     # Cached class instance variable for what distro we are running on
     @dist_class = nil
 
@@ -53,7 +51,7 @@ module LinuxAdmin
 
       @network_conf[:mac] = parse_ip_output(ip_output, %r{link/ether}, 1)
 
-      ip_route_res = run!(cmd("ip"), :params => ["route"])
+      ip_route_res = Common.run!(Common.cmd("ip"), :params => ["route"])
       @network_conf[:gateway] = parse_ip_output(ip_route_res.output, /^default/, 2) if ip_route_res.success?
       true
     rescue AwesomeSpawn::CommandResultError => e
@@ -121,14 +119,14 @@ module LinuxAdmin
     #
     # @return [Boolean] whether the command succeeded or not
     def start
-      run(cmd("ifup"), :params => [@interface]).success?
+      Common.run(Common.cmd("ifup"), :params => [@interface]).success?
     end
 
     # Brings down the network interface
     #
     # @return [Boolean] whether the command succeeded or not
     def stop
-      run(cmd("ifdown"), :params => [@interface]).success?
+      Common.run(Common.cmd("ifdown"), :params => [@interface]).success?
     end
 
     private
@@ -149,7 +147,7 @@ module LinuxAdmin
     # @return [String] The command output
     # @raise [NetworkInterfaceError] if the command fails
     def ip_show
-      run!(cmd("ip"), :params => ["addr", "show", @interface]).output
+      Common.run!(Common.cmd("ip"), :params => ["addr", "show", @interface]).output
     rescue AwesomeSpawn::CommandResultError => e
       raise NetworkInterfaceError.new(e.message, e.result)
     end

--- a/lib/linux_admin/package.rb
+++ b/lib/linux_admin/package.rb
@@ -1,5 +1,4 @@
 module LinuxAdmin
   class Package
-    extend Common
   end
 end

--- a/lib/linux_admin/physical_volume.rb
+++ b/lib/linux_admin/physical_volume.rb
@@ -1,8 +1,5 @@
 module LinuxAdmin
   class PhysicalVolume < Volume
-    include Common
-    extend Common
-
     # physical volume device name
     attr_accessor :device_name
 
@@ -29,7 +26,7 @@ module LinuxAdmin
     end
 
     def attach_to(vg)
-      run!(cmd(:vgextend),
+      Common.run!(Common.cmd(:vgextend),
           :params => [vg.name, @device_name])
       self.volume_group = vg
       self
@@ -38,7 +35,7 @@ module LinuxAdmin
     # specify disk or partition instance to create physical volume on
     def self.create(device)
       self.scan # initialize local physical volumes
-      run!(cmd(:pvcreate),
+      Common.run!(Common.cmd(:pvcreate),
           :params => { nil => device.path})
       pv  = PhysicalVolume.new(:device_name  => device.path,
                                :volume_group => nil,
@@ -49,7 +46,7 @@ module LinuxAdmin
 
     def self.scan
       @pvs ||= begin
-        scan_volumes(cmd(:pvdisplay)) do |fields, vg|
+        scan_volumes(Common.cmd(:pvdisplay)) do |fields, vg|
           PhysicalVolume.new(:device_name  => fields[0],
                              :volume_group => vg,
                              :size         => fields[2].to_i)

--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -1,6 +1,5 @@
 module LinuxAdmin
   class RegistrationSystem
-    include Common
     include Logging
 
     def self.registration_type(reload = false)

--- a/lib/linux_admin/registration_system/rhn.rb
+++ b/lib/linux_admin/registration_system/rhn.rb
@@ -37,7 +37,7 @@ module LinuxAdmin
       params["--systemorgid="]    = options[:org]               if options[:server_url] && options[:org]
       params["--sslCACert="]      = INSTALLED_SERVER_CERT_PATH  if certificate_installed
 
-      run!(cmd, :params => params)
+      Common.run!(cmd, :params => params)
     end
 
     def enable_channel(repo, options)
@@ -45,7 +45,7 @@ module LinuxAdmin
       params    = user_pwd(options).merge("--channel=" => repo)
 
       logger.info("#{self.class.name}##{__method__} Enabling channel: #{repo}")
-      run!(cmd, :params => params)
+      Common.run!(cmd, :params => params)
     end
     alias_method :subscribe,    :enable_channel
     alias_method :enable_repo,  :enable_channel
@@ -54,14 +54,14 @@ module LinuxAdmin
       cmd       = "rhn-channel -r"
       params    = user_pwd(options).merge("--channel=" => repo)
 
-      run!(cmd, :params => params)
+      Common.run!(cmd, :params => params)
     end
     alias_method :disable_repo, :disable_channel
 
     def enabled_channels
       cmd = "rhn-channel -l"
 
-      run!(cmd).output.split("\n").compact
+      Common.run!(cmd).output.split("\n").compact
     end
     alias_method :enabled_repos, :enabled_channels
     alias_method :subscribed_products, :enabled_channels
@@ -70,7 +70,7 @@ module LinuxAdmin
       cmd     = "rhn-channel -L"
       params  = user_pwd(options)
 
-      run!(cmd, :params => params).output.chomp.split("\n").compact
+      Common.run!(cmd, :params => params).output.chomp.split("\n").compact
     end
 
     def all_repos(options)

--- a/lib/linux_admin/registration_system/subscription_manager.rb
+++ b/lib/linux_admin/registration_system/subscription_manager.rb
@@ -3,7 +3,7 @@ require 'date'
 module LinuxAdmin
   class SubscriptionManager < RegistrationSystem
     def run!(cmd, options = {})
-      super(cmd, options)
+      Common.run!(cmd, options)
     rescue AwesomeSpawn::CommandResultError => err
       raise CredentialError.new(err.result) if err.result.error.downcase.include?("invalid username or password")
       raise
@@ -16,7 +16,7 @@ module LinuxAdmin
     end
 
     def registered?
-      run("subscription-manager identity").exit_status == 0
+      Common.run("subscription-manager identity").exit_status == 0
     end
 
     def refresh

--- a/lib/linux_admin/rpm.rb
+++ b/lib/linux_admin/rpm.rb
@@ -1,11 +1,13 @@
 module LinuxAdmin
   class Rpm < Package
+    extend Logging
+
     def self.rpm_cmd
-      cmd(:rpm)
+      Common.cmd(:rpm)
     end
 
     def self.list_installed
-      out = run!("#{rpm_cmd} -qa --qf \"%{NAME} %{VERSION}-%{RELEASE}\n\"").output
+      out = Common.run!("#{rpm_cmd} -qa --qf \"%{NAME} %{VERSION}-%{RELEASE}\n\"").output
       out.split("\n").each_with_object({}) do |line, pkg_hash|
         name, ver = line.split(" ")
         pkg_hash[name] = ver
@@ -17,13 +19,13 @@ module LinuxAdmin
     #   Rpm.import_key("/etc/pki/my-gpg-key")
     def self.import_key(file)
       logger.info("#{self.class.name}##{__method__} Importing RPM-GPG-KEY: #{file}")
-      run!("rpm", :params => {"--import" => file})
+      Common.run!("rpm", :params => {"--import" => file})
     end
 
     def self.info(pkg)
       params = { "-qi" => pkg}
       in_description = false
-      out = run!(rpm_cmd, :params => params).output
+      out = Common.run!(rpm_cmd, :params => params).output
       # older versions of rpm may have multiple fields per line,
       # split up lines with multiple tags/values:
       out.gsub!(/(^.*:.*)\s\s+(.*:.*)$/, "\\1\n\\2")
@@ -47,7 +49,7 @@ module LinuxAdmin
       cmd     = "rpm -U"
       params  = { nil => pkg }
 
-      run(cmd, :params => params).exit_status == 0
+      Common.run(cmd, :params => params).exit_status == 0
     end
   end
 end

--- a/lib/linux_admin/service.rb
+++ b/lib/linux_admin/service.rb
@@ -1,7 +1,5 @@
 module LinuxAdmin
   class Service
-    extend Common
-    include Common
     include Logging
 
     def self.service_type(reload = false)
@@ -34,7 +32,7 @@ module LinuxAdmin
     private
 
     def self.service_type_uncached
-      cmd?(:systemctl) ? SystemdService : SysVInitService
+      Common.cmd?(:systemctl) ? SystemdService : SysVInitService
     end
     private_class_method :service_type_uncached
   end

--- a/lib/linux_admin/service/sys_v_init_service.rb
+++ b/lib/linux_admin/service/sys_v_init_service.rb
@@ -1,38 +1,38 @@
 module LinuxAdmin
   class SysVInitService < Service
     def running?
-      run(cmd(:service),
-          :params => { nil => [name, "status"] }).exit_status == 0
+      Common.run(Common.cmd(:service),
+                 :params => {nil => [name, "status"]}).exit_status == 0
     end
 
     def enable
-      run!(cmd(:chkconfig),
-          :params => { nil => [name, "on"] })
+      Common.run!(Common.cmd(:chkconfig),
+                  :params => {nil => [name, "on"]})
       self
     end
 
     def disable
-      run!(cmd(:chkconfig),
-          :params => { nil => [name, "off"] })
+      Common.run!(Common.cmd(:chkconfig),
+                  :params => {nil => [name, "off"]})
       self
     end
 
     def start
-      run!(cmd(:service),
-          :params => { nil => [name, "start"] })
+      Common.run!(Common.cmd(:service),
+                  :params => {nil => [name, "start"]})
       self
     end
 
     def stop
-      run!(cmd(:service),
-          :params => { nil => [name, "stop"] })
+      Common.run!(Common.cmd(:service),
+                  :params => {nil => [name, "stop"]})
       self
     end
 
     def restart
       status =
-        run(cmd(:service),
-          :params => { nil => [name, "restart"] }).exit_status
+        Common.run(Common.cmd(:service),
+                   :params => {nil => [name, "restart"]}).exit_status
 
       # attempt to manually stop/start if restart fails
       if status != 0

--- a/lib/linux_admin/service/systemd_service.rb
+++ b/lib/linux_admin/service/systemd_service.rb
@@ -1,38 +1,38 @@
 module LinuxAdmin
   class SystemdService < Service
     def running?
-      run(cmd(:systemctl),
-          :params => {nil => ["status", name]}).exit_status == 0
+      Common.run(Common.cmd(:systemctl),
+                 :params => {nil => ["status", name]}).exit_status == 0
     end
 
     def enable
-      run!(cmd(:systemctl),
-           :params => {nil => ["enable", name]})
+      Common.run!(Common.cmd(:systemctl),
+                  :params => {nil => ["enable", name]})
       self
     end
 
     def disable
-      run!(cmd(:systemctl),
-           :params => {nil => ["disable", name]})
+      Common.run!(Common.cmd(:systemctl),
+                  :params => {nil => ["disable", name]})
       self
     end
 
     def start
-      run!(cmd(:systemctl),
-           :params => {nil => ["start", name]})
+      Common.run!(Common.cmd(:systemctl),
+                  :params => {nil => ["start", name]})
       self
     end
 
     def stop
-      run!(cmd(:systemctl),
-           :params => {nil => ["stop", name]})
+      Common.run!(Common.cmd(:systemctl),
+                  :params => {nil => ["stop", name]})
       self
     end
 
     def restart
       status =
-        run(cmd(:systemctl),
-            :params => {nil => ["restart", name]}).exit_status
+        Common.run(Common.cmd(:systemctl),
+                   :params => {nil => ["restart", name]}).exit_status
 
       # attempt to manually stop/start if restart fails
       if status != 0

--- a/lib/linux_admin/system.rb
+++ b/lib/linux_admin/system.rb
@@ -1,14 +1,12 @@
 module LinuxAdmin
   class System
-    extend Common
-
     def self.reboot!
-      run!(cmd(:shutdown),
+      Common.run!(Common.cmd(:shutdown),
           :params => { "-r" => "now" })
     end
 
     def self.shutdown!
-      run!(cmd(:shutdown),
+      Common.run!(Common.cmd(:shutdown),
           :params => { "-h" => "0" })
     end
   end

--- a/lib/linux_admin/time_date.rb
+++ b/lib/linux_admin/time_date.rb
@@ -1,12 +1,11 @@
 module LinuxAdmin
   class TimeDate
-    extend Common
     COMMAND = 'timedatectl'
 
     TimeCommandError = Class.new(StandardError)
 
     def self.system_timezone_detailed
-      result = run(cmd(COMMAND), :params => ["status"])
+      result = Common.run(Common.cmd(COMMAND), :params => ["status"])
       result.output.split("\n").each do |l|
         return l.split(':')[1].strip if l =~ /Time.*zone/
       end
@@ -17,13 +16,13 @@ module LinuxAdmin
     end
 
     def self.system_time=(time)
-      run!(cmd(COMMAND), :params => ["set-time", "#{time.strftime("%F %T")}", :adjust_system_clock])
+      Common.run!(Common.cmd(COMMAND), :params => ["set-time", "#{time.strftime("%F %T")}", :adjust_system_clock])
     rescue AwesomeSpawn::CommandResultError => e
       raise TimeCommandError, e.message
     end
 
     def self.system_timezone=(zone)
-      run!(cmd(COMMAND), :params => ["set-timezone", zone])
+      Common.run!(Common.cmd(COMMAND), :params => ["set-timezone", zone])
     rescue AwesomeSpawn::CommandResultError => e
       raise TimeCommandError, e.message
     end

--- a/lib/linux_admin/volume.rb
+++ b/lib/linux_admin/volume.rb
@@ -15,7 +15,7 @@ module LinuxAdmin
     def self.scan_volumes(cmd)
       volumes = []
 
-      out = run!(cmd, :params => { '-c' => nil}).output
+      out = Common.run!(cmd, :params => {'-c' => nil}).output
 
       out.each_line do |line|
         fields, vg = process_volume_display_line(line.lstrip)

--- a/lib/linux_admin/volume_group.rb
+++ b/lib/linux_admin/volume_group.rb
@@ -1,8 +1,5 @@
 module LinuxAdmin
   class VolumeGroup
-    include Common
-    extend Common
-
     # volume group name
     attr_accessor :name
 
@@ -29,22 +26,22 @@ module LinuxAdmin
     end
 
     def attach_to(lv)
-      run!(cmd(:lvextend),
-          :params => [lv.name, self.name])
+      Common.run!(Common.cmd(:lvextend),
+                  :params => [lv.name, name])
       self
     end
 
     def extend_with(pv)
-      run!(cmd(:vgextend),
-          :params => [@name, pv.device_name])
+      Common.run!(Common.cmd(:vgextend),
+                  :params => [@name, pv.device_name])
       pv.volume_group = self
       self
     end
 
     def self.create(name, pv)
       self.scan # initialize local volume groups
-      run!(cmd(:vgcreate),
-          :params => [name, pv.device_name])
+      Common.run!(Common.cmd(:vgcreate),
+                  :params => [name, pv.device_name])
       vg = VolumeGroup.new :name => name
       pv.volume_group = vg
       @vgs << vg
@@ -55,7 +52,7 @@ module LinuxAdmin
       @vgs ||= begin
         vgs = []
 
-        out = run!(cmd(:vgdisplay), :params => { '-c' => nil}).output
+        out = Common.run!(Common.cmd(:vgdisplay), :params => {'-c' => nil}).output
 
         out.each_line do |line|
           fields = line.lstrip.split(':')

--- a/lib/linux_admin/yum.rb
+++ b/lib/linux_admin/yum.rb
@@ -3,8 +3,6 @@ require 'inifile'
 
 module LinuxAdmin
   class Yum
-    extend Common
-
     def self.create_repo(path, options = {})
       raise ArgumentError, "path is required" unless path
       options = options.reverse_merge(:database => true, :unique_file_names => true)
@@ -16,7 +14,7 @@ module LinuxAdmin
       params["--database"]            = nil  if options[:database]
       params["--unique-md-filenames"] = nil  if options[:unique_file_names]
 
-      run!(cmd, :params => params)
+      Common.run!(cmd, :params => params)
     end
 
     def self.download_packages(path, packages, options = {})
@@ -34,7 +32,7 @@ module LinuxAdmin
       params["-a"]  = options[:arch] if options[:arch]
       params[nil]   = packages
 
-      run!(cmd, :params => params)
+      Common.run!(cmd, :params => params)
     end
 
     def self.repo_settings
@@ -45,7 +43,7 @@ module LinuxAdmin
       cmd    = "yum check-update"
       params = {nil => packages} unless packages.blank?
 
-      exitstatus = run(cmd, :params => params).exit_status
+      exitstatus = Common.run(cmd, :params => params).exit_status
       case exitstatus
       when 0;   false
       when 100; true
@@ -57,7 +55,7 @@ module LinuxAdmin
       cmd    = "yum -y update"
       params = {nil => packages} unless packages.blank?
 
-      out = run!(cmd, :params => params)
+      out = Common.run!(cmd, :params => params)
 
       # Handle errors that exit 0  https://bugzilla.redhat.com/show_bug.cgi?id=1141318
       raise AwesomeSpawn::CommandResultError.new(out.error, out) if out.error.include?("No Match for argument")
@@ -71,7 +69,7 @@ module LinuxAdmin
       cmd    = "repoquery --qf=\"%{name} %{version}\""
       params = {nil => packages}
 
-      out = run!(cmd, :params => params).output
+      out = Common.run!(cmd, :params => params).output
 
       out.split("\n").each_with_object({}) do |i, versions|
         name, version         = i.split(" ", 2)
@@ -84,7 +82,7 @@ module LinuxAdmin
 
       cmd     = "yum repolist"
       params  = {nil => scope}
-      output  = run!(cmd, :params => params).output
+      output  = Common.run!(cmd, :params => params).output
 
       parse_repo_list_output(output)
     end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -1,37 +1,35 @@
 describe LinuxAdmin::Common do
-  subject { Class.new { include LinuxAdmin::Common }.new }
-
   describe "#cmd" do
     it "looks up local command from id" do
-      expect(subject.cmd(:dd)).to match(/bin\/dd/)
+      expect(described_class.cmd(:dd)).to match(%r{bin/dd})
     end
 
     it "returns nil when it can't find the command" do
-      expect(subject.cmd(:kasgbdlcvjhals)).to be_nil
+      expect(described_class.cmd(:kasgbdlcvjhals)).to be_nil
     end
   end
 
   describe "#cmd?" do
     it "returns true when the command exists" do
-      expect(subject.cmd?(:dd)).to be true
+      expect(described_class.cmd?(:dd)).to be true
     end
 
     it "returns false when the command doesn't exist" do
-      expect(subject.cmd?(:kasgbdlcvjhals)).to be false
+      expect(described_class.cmd?(:kasgbdlcvjhals)).to be false
     end
   end
 
   describe "#run" do
     it "runs a command with AwesomeSpawn.run" do
       expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
-      subject.run("echo", nil => "test")
+      described_class.run("echo", nil => "test")
     end
   end
 
   describe "#run!" do
     it "runs a command with AwesomeSpawn.run!" do
       expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
-      subject.run!("echo", nil => "test")
+      described_class.run!("echo", nil => "test")
     end
   end
 end

--- a/spec/deb_spec.rb
+++ b/spec/deb_spec.rb
@@ -37,9 +37,9 @@ Origin: Ubuntu
 Supported: 9m
 Task: kubuntu-desktop, kubuntu-full, kubuntu-active, kubuntu-active-desktop, kubuntu-active-full, kubuntu-active, edubuntu-desktop-gnome, ubuntustudio-font-meta
 EOS
-      expect(described_class).to receive(:run!).
-                      with(described_class::APT_CACHE_CMD, :params => ["show", "ruby"]).
-                      and_return(double(:output => data))
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(described_class::APT_CACHE_CMD, :params => %w(show ruby))
+        .and_return(double(:output => data))
       metadata = described_class.info("ruby")
       expect(metadata['package']).to eq('ruby')
       expect(metadata['priority']).to eq('optional')

--- a/spec/hosts_spec.rb
+++ b/spec/hosts_spec.rb
@@ -81,20 +81,20 @@ describe LinuxAdmin::Hosts do
   describe "#hostname=" do
     it "sets the hostname using hostnamectl when the command exists" do
       spawn_args = [
-        @instance.cmd('hostnamectl'),
+        LinuxAdmin::Common.cmd('hostnamectl'),
         :params => ['set-hostname', TEST_HOSTNAME]
       ]
-      expect(@instance).to receive(:cmd?).with("hostnamectl").and_return(true)
+      expect(LinuxAdmin::Common).to receive(:cmd?).with("hostnamectl").and_return(true)
       expect(AwesomeSpawn).to receive(:run!).with(*spawn_args)
       @instance.hostname = TEST_HOSTNAME
     end
 
     it "sets the hostname with hostname when hostnamectl does not exist" do
       spawn_args = [
-        @instance.cmd('hostname'),
+        LinuxAdmin::Common.cmd('hostname'),
         :params => {:file => "/etc/hostname"}
       ]
-      expect(@instance).to receive(:cmd?).with("hostnamectl").and_return(false)
+      expect(LinuxAdmin::Common).to receive(:cmd?).with("hostnamectl").and_return(false)
       expect(File).to receive(:write).with("/etc/hostname", TEST_HOSTNAME)
       expect(AwesomeSpawn).to receive(:run!).with(*spawn_args)
       @instance.hostname = TEST_HOSTNAME
@@ -103,7 +103,7 @@ describe LinuxAdmin::Hosts do
 
   describe "#hostname" do
     let(:spawn_args) do
-      [@instance.cmd('hostname'), {}]
+      [LinuxAdmin::Common.cmd('hostname'), {}]
     end
 
     it "returns the hostname" do

--- a/spec/ip_address_spec.rb
+++ b/spec/ip_address_spec.rb
@@ -2,22 +2,22 @@ describe LinuxAdmin::IpAddress do
   let(:ip) { described_class.new }
 
   ADDR_SPAWN_ARGS = [
-    described_class.new.cmd("hostname"),
+    LinuxAdmin::Common.cmd("hostname"),
     :params => ["-I"]
   ]
 
   MAC_SPAWN_ARGS = [
-    described_class.new.cmd("ip"),
+    LinuxAdmin::Common.cmd("ip"),
     :params => %w(addr show eth0)
   ]
 
   MASK_SPAWN_ARGS = [
-    described_class.new.cmd("ifconfig"),
+    LinuxAdmin::Common.cmd("ifconfig"),
     :params => %w(eth0)
   ]
 
   GW_SPAWN_ARGS = [
-    described_class.new.cmd("ip"),
+    LinuxAdmin::Common.cmd("ip"),
     :params => %w(route)
   ]
 

--- a/spec/mountable_spec.rb
+++ b/spec/mountable_spec.rb
@@ -12,7 +12,7 @@ describe LinuxAdmin::Mountable do
 
     # stub out calls that modify system
     allow(FileUtils).to receive(:mkdir)
-    allow(@mountable).to receive(:run!)
+    allow(LinuxAdmin::Common).to receive(:run!)
 
     @mount_out1 = <<eos
 /dev/sda on /mnt/usb type vfat (rw)
@@ -25,20 +25,21 @@ eos
 
   describe "#mount_point_exists?" do
     it "uses mount" do
-      expect(TestMountable).to receive(:run!).with(TestMountable.cmd(:mount)).and_return(double(:output => ""))
+      expect(LinuxAdmin::Common).to receive(:run!).with(LinuxAdmin::Common.cmd(:mount))
+        .and_return(double(:output => ""))
       TestMountable.mount_point_exists?('/mnt/usb')
     end
 
     context "disk mounted at specified location" do
       it "returns true" do
-        expect(TestMountable).to receive(:run!).and_return(double(:output => @mount_out1))
+        expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out1))
         expect(TestMountable.mount_point_exists?('/mnt/usb')).to be_truthy
       end
     end
 
     context "no disk mounted at specified location" do
       it "returns false" do
-        expect(TestMountable).to receive(:run!).and_return(double(:output => @mount_out2))
+        expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out2))
         expect(TestMountable.mount_point_exists?('/mnt/usb')).to be_falsey
       end
     end
@@ -46,20 +47,21 @@ eos
 
   describe "#mount_point_available?" do
     it "uses mount" do
-      expect(TestMountable).to receive(:run!).with(TestMountable.cmd(:mount)).and_return(double(:output => ""))
+      expect(LinuxAdmin::Common).to receive(:run!).with(LinuxAdmin::Common.cmd(:mount))
+        .and_return(double(:output => ""))
       TestMountable.mount_point_available?('/mnt/usb')
     end
 
     context "disk mounted at specified location" do
       it "returns false" do
-        expect(TestMountable).to receive(:run!).and_return(double(:output => @mount_out1))
+        expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out1))
         expect(TestMountable.mount_point_available?('/mnt/usb')).to be_falsey
       end
     end
 
     context "no disk mounted at specified location" do
       it "returns true" do
-        expect(TestMountable).to receive(:run!).and_return(double(:output => @mount_out2))
+        expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out2))
         expect(TestMountable.mount_point_available?('/mnt/usb')).to be_truthy
       end
     end
@@ -67,14 +69,14 @@ eos
 
   describe "#format_to" do
     it "uses mke2fs" do
-      expect(@mountable).to receive(:run!).
-         with(@mountable.cmd(:mke2fs),
-              :params => { '-t' => 'ext4', nil => '/dev/foo'})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:mke2fs),
+              :params => {'-t' => 'ext4', nil => '/dev/foo'})
       @mountable.format_to('ext4')
     end
 
     it "sets fs type" do
-      expect(@mountable).to receive(:run!) # ignore actual formatting cmd
+      expect(LinuxAdmin::Common).to receive(:run!) # ignore actual formatting cmd
       @mountable.format_to('ext4')
       expect(@mountable.fs_type).to eq('ext4')
     end
@@ -83,19 +85,19 @@ eos
   describe "#mount" do
     it "sets mount point" do
       # ignore actual mount cmds
-      expect(@mountable).to receive(:run!).and_return(double(:output => ""))
-      expect(TestMountable).to receive(:run!).and_return(double(:output => ""))
+      expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => ""))
+      expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => ""))
 
       expect(@mountable.mount('/mnt/sda2')).to eq('/mnt/sda2')
       expect(@mountable.mount_point).to eq('/mnt/sda2')
     end
-    
+
     context "mountpoint does not exist" do
       it "creates mountpoint" do
         expect(TestMountable).to receive(:mount_point_exists?).and_return(false)
         expect(File).to receive(:directory?).with('/mnt/sda2').and_return(false)
         expect(FileUtils).to receive(:mkdir).with('/mnt/sda2')
-        expect(@mountable).to receive(:run!) # ignore actual mount cmd
+        expect(LinuxAdmin::Common).to receive(:run!) # ignore actual mount cmd
         @mountable.mount '/mnt/sda2'
       end
     end
@@ -110,9 +112,9 @@ eos
 
     it "mounts partition" do
       expect(TestMountable).to receive(:mount_point_exists?).and_return(false)
-      expect(@mountable).to receive(:run!).
-         with(@mountable.cmd(:mount),
-              :params => { nil => ['/dev/foo', '/mnt/sda2']})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:mount),
+              :params => {nil => ['/dev/foo', '/mnt/sda2']})
       @mountable.mount '/mnt/sda2'
     end
   end
@@ -120,9 +122,9 @@ eos
   describe "#umount" do
     it "unmounts partition" do
       @mountable.mount_point = '/mnt/sda2'
-      expect(@mountable).to receive(:run!).with(@mountable.cmd(:umount), :params => { nil => ['/mnt/sda2']})
+      expect(LinuxAdmin::Common).to receive(:run!).with(LinuxAdmin::Common.cmd(:umount),
+                                                        :params => {nil => ['/mnt/sda2']})
       @mountable.umount
     end
   end
-
 end

--- a/spec/network_interface_spec.rb
+++ b/spec/network_interface_spec.rb
@@ -58,25 +58,23 @@ describe LinuxAdmin::NetworkInterface do
   end
 
   context "on all systems" do
-    common_inst = Class.new { include LinuxAdmin::Common }.new
-
     IP_SHOW_ARGS = [
-      common_inst.cmd("ip"),
+      LinuxAdmin::Common.cmd("ip"),
       :params => %w(addr show eth0)
     ]
 
     IP_ROUTE_ARGS = [
-      common_inst.cmd("ip"),
+      LinuxAdmin::Common.cmd("ip"),
       :params => %w(route)
     ]
 
     IFUP_ARGS = [
-      common_inst.cmd("ifup"),
+      LinuxAdmin::Common.cmd("ifup"),
       :params => ["eth0"]
     ]
 
     IFDOWN_ARGS = [
-      common_inst.cmd("ifdown"),
+      LinuxAdmin::Common.cmd("ifdown"),
       :params => ["eth0"]
     ]
 

--- a/spec/partition_spec.rb
+++ b/spec/partition_spec.rb
@@ -15,7 +15,7 @@ describe LinuxAdmin::Partition do
       it "sets default mount_point" do
         expect(described_class).to receive(:mount_point_exists?).and_return(false)
         expect(File).to receive(:directory?).with('/mnt/sda2').and_return(true)
-        expect(@partition).to receive(:run!)
+        expect(LinuxAdmin::Common).to receive(:run!)
         @partition.mount
         expect(@partition.mount_point).to eq('/mnt/sda2')
       end

--- a/spec/rhn_spec.rb
+++ b/spec/rhn_spec.rb
@@ -39,7 +39,7 @@ describe LinuxAdmin::Rhn do
         run_params.store_path(:params, "--sslCACert=", "/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT")
         base_options.store_path(:server_url, "https://server.url")
 
-        expect_any_instance_of(described_class).to receive(:run!).once.with("rhnreg_ks", run_params)
+        expect(LinuxAdmin::Common).to receive(:run!).once.with("rhnreg_ks", run_params)
         expect(LinuxAdmin::Rpm).to receive(:upgrade).with("http://server.url/pub/rhn-org-trusted-ssl-cert-1.0-1.noarch.rpm")
         expect(LinuxAdmin::Rpm).to receive(:list_installed).and_return({"rhn-org-trusted-ssl-cert" => "1.0"})
 
@@ -47,7 +47,7 @@ describe LinuxAdmin::Rhn do
       end
 
       it "without server_url" do
-        expect_any_instance_of(described_class).to receive(:run!).once.with("rhnreg_ks", run_params)
+        expect(LinuxAdmin::Common).to receive(:run!).once.with("rhnreg_ks", run_params)
         expect_any_instance_of(described_class).not_to receive(:install_server_certificate)
         expect(LinuxAdmin::Rpm).to receive(:list_installed).and_return({"rhn-org-trusted-ssl-cert" => nil})
 
@@ -56,7 +56,11 @@ describe LinuxAdmin::Rhn do
     end
 
     it "with activation key" do
-      expect_any_instance_of(described_class).to receive(:run!).once.with("rhnreg_ks", {:params=>{"--activationkey="=>"123abc", "--proxy="=>"1.2.3.4", "--proxyUser="=>"ProxyUser", "--proxyPassword="=>"ProxyPass"}})
+      expect(LinuxAdmin::Common).to receive(:run!).once.with("rhnreg_ks",
+                                                             :params => {"--activationkey=" => "123abc",
+                                                                         "--proxy="         => "1.2.3.4",
+                                                                         "--proxyUser="     => "ProxyUser",
+                                                                         "--proxyPassword=" => "ProxyPass"})
       expect(LinuxAdmin::Rpm).to receive(:list_installed).and_return({"rhn-org-trusted-ssl-cert" => nil})
 
       described_class.new.register(
@@ -69,19 +73,25 @@ describe LinuxAdmin::Rhn do
   end
 
   it "#enable_channel" do
-    expect_any_instance_of(described_class).to receive(:run!).once.with("rhn-channel -a", {:params=>{"--user="=>"SomeUser", "--password="=>"SomePass", "--channel="=>123}})
+    expect(LinuxAdmin::Common).to receive(:run!).once.with("rhn-channel -a",
+                                                           :params => {"--user="     => "SomeUser",
+                                                                       "--password=" => "SomePass",
+                                                                       "--channel="  => 123})
 
     described_class.new.enable_channel(123, :username => "SomeUser", :password => "SomePass")
   end
 
   it "#enabled_channels" do
-    expect_any_instance_of(described_class).to receive(:run!).once.with("rhn-channel -l").and_return(double(:output => sample_output("rhn/output_rhn-channel_list")))
+    expect(LinuxAdmin::Common).to receive(:run!).once.with("rhn-channel -l")
+      .and_return(double(:output => sample_output("rhn/output_rhn-channel_list")))
 
     expect(described_class.new.enabled_channels).to eq(["rhel-x86_64-server-6", "rhel-x86_64-server-6-cf-me-2"])
   end
 
   it "#disable_channel" do
-    expect_any_instance_of(described_class).to receive(:run!).once.with("rhn-channel -r", {:params=>{"--user="=>"SomeUser", "--password="=>"SomePass", "--channel="=>123}})
+    expect(LinuxAdmin::Common).to receive(:run!).once.with("rhn-channel -r", :params => {"--user="     => "SomeUser",
+                                                                                         "--password=" => "SomePass",
+                                                                                         "--channel="  => 123})
 
     described_class.new.disable_channel(123, :username => "SomeUser", :password => "SomePass")
   end
@@ -105,7 +115,8 @@ describe LinuxAdmin::Rhn do
       }
     }
 
-    expect_any_instance_of(described_class).to receive(:run!).once.with(cmd, params).and_return(double(:output => sample_output("rhn/output_rhn-channel_list_available")))
+    expect(LinuxAdmin::Common).to receive(:run!).once.with(cmd, params)
+      .and_return(double(:output => sample_output("rhn/output_rhn-channel_list_available")))
 
     expect(described_class.new.available_channels(credentials)).to eq(expected)
   end
@@ -123,8 +134,10 @@ describe LinuxAdmin::Rhn do
       {:repo_id => "rhel-x86_64-server-6",              :enabled => true}
     ]
 
-    expect_any_instance_of(described_class).to receive(:run!).once.and_return(double(:output => sample_output("rhn/output_rhn-channel_list_available")))
-    expect_any_instance_of(described_class).to receive(:run!).once.with("rhn-channel -l").and_return(double(:output => sample_output("rhn/output_rhn-channel_list")))
+    expect(LinuxAdmin::Common).to receive(:run!).once
+      .and_return(double(:output => sample_output("rhn/output_rhn-channel_list_available")))
+    expect(LinuxAdmin::Common).to receive(:run!).once.with("rhn-channel -l")
+      .and_return(double(:output => sample_output("rhn/output_rhn-channel_list")))
 
     expect(described_class.new.all_repos(credentials)).to eq(expected)
   end

--- a/spec/rpm_spec.rb
+++ b/spec/rpm_spec.rb
@@ -1,6 +1,7 @@
 describe LinuxAdmin::Rpm do
   it ".list_installed" do
-    allow(described_class).to receive_messages(:run! => double(:output => sample_output("rpm/cmd_output_for_list_installed")))
+    allow(LinuxAdmin::Common).to receive(:run!)
+      .and_return(double(:output => sample_output("rpm/cmd_output_for_list_installed")))
     expect(described_class.list_installed).to eq({
       "ruby193-rubygem-some_really_long_name" =>"1.0.7-1.el6",
       "fipscheck-lib"                         =>"1.2.0-7.el6",
@@ -26,7 +27,7 @@ describe LinuxAdmin::Rpm do
   end
 
   it ".import_key" do
-    expect(described_class).to receive(:run!).with("rpm", {:params => {"--import" => "abc"}})
+    expect(LinuxAdmin::Common).to receive(:run!).with("rpm", :params => {"--import" => "abc"})
     expect { described_class.import_key("abc") }.to_not raise_error
   end
 
@@ -59,7 +60,7 @@ straight-forward, and extensible.
 EOS
       arguments = [described_class.rpm_cmd, :params => {"-qi" => "ruby"}]
       result = AwesomeSpawn::CommandResult.new("", data, "", 0)
-      expect(described_class).to receive(:run!).with(*arguments).and_return(result)
+      expect(LinuxAdmin::Common).to receive(:run!).with(*arguments).and_return(result)
       metadata = described_class.info("ruby")
       expect(metadata['name']).to eq('ruby')
       expect(metadata['version']).to eq('2.0.0.247')
@@ -77,7 +78,8 @@ EOS
   end
 
   it ".upgrade" do
-    expect(described_class).to receive(:run).with("rpm -U", {:params=>{nil=>"abc"}}).and_return(double(:exit_status => 0))
+    expect(LinuxAdmin::Common).to receive(:run).with("rpm -U", :params => {nil => "abc"})
+      .and_return(double(:exit_status => 0))
     expect(described_class.upgrade("abc")).to be_truthy
   end
 end

--- a/spec/service/sys_v_init_service_spec.rb
+++ b/spec/service/sys_v_init_service_spec.rb
@@ -5,24 +5,24 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#running?" do
     it "checks service" do
-      expect(@service).to receive(:run).
-         with(@service.cmd(:service),
-              :params => { nil => ['foo', 'status']}).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run)
+        .with(LinuxAdmin::Common.cmd(:service),
+              :params => {nil => %w(foo status)}).and_return(double(:exit_status => 0))
       @service.running?
     end
 
     context "service is running" do
       it "returns true" do
         @service = described_class.new :id => :foo
-        expect(@service).to receive(:run).and_return(double(:exit_status => 0))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
         expect(@service).to be_running
-     end
+      end
     end
 
     context "service is not running" do
       it "returns false" do
         @service = described_class.new :id => :foo
-        expect(@service).to receive(:run).and_return(double(:exit_status => 1))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
         expect(@service).not_to be_running
       end
     end
@@ -30,71 +30,71 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#enable" do
     it "enables service" do
-      expect(@service).to receive(:run!).
-         with(@service.cmd(:chkconfig),
-              :params => { nil => [ 'foo', 'on']})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:chkconfig),
+              :params => {nil => %w(foo on)})
       @service.enable
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!) # stub out cmd invocation
+      expect(LinuxAdmin::Common).to receive(:run!) # stub out cmd invocation
       expect(@service.enable).to eq(@service)
     end
   end
 
   describe "#disable" do
     it "disable service" do
-      expect(@service).to receive(:run!).
-         with(@service.cmd(:chkconfig),
-              :params => { nil => [ 'foo', 'off']})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:chkconfig),
+              :params => {nil => %w(foo off)})
       @service.disable
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.disable).to eq(@service)
     end
   end
 
   describe "#start" do
     it "starts service" do
-      expect(@service).to receive(:run!).
-         with(@service.cmd(:service),
-              :params => { nil => [ 'foo', 'start']})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:service),
+              :params => {nil => %w(foo start)})
       @service.start
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.start).to eq(@service)
     end
   end
 
   describe "#stop" do
     it "stops service" do
-      expect(@service).to receive(:run!).
-         with(@service.cmd(:service),
-              :params => { nil => [ 'foo', 'stop']})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:service),
+              :params => {nil => %w(foo stop)})
       @service.stop
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.stop).to eq(@service)
     end
   end
 
   describe "#restart" do
     it "stops service" do
-      expect(@service).to receive(:run).
-         with(@service.cmd(:service),
-              :params => { nil => [ 'foo', 'restart']}).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run)
+        .with(LinuxAdmin::Common.cmd(:service),
+              :params => {nil => %w(foo restart)}).and_return(double(:exit_status => 0))
       @service.restart
     end
 
     context "service restart fails" do
       it "manually stops/starts service" do
-        expect(@service).to receive(:run).and_return(double(:exit_status => 1))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
         expect(@service).to receive(:stop)
         expect(@service).to receive(:start)
         @service.restart
@@ -102,9 +102,8 @@ describe LinuxAdmin::SysVInitService do
     end
 
     it "returns self" do
-      expect(@service).to receive(:run).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
       expect(@service.restart).to eq(@service)
     end
   end
-
 end

--- a/spec/service/systemd_service_spec.rb
+++ b/spec/service/systemd_service_spec.rb
@@ -5,96 +5,96 @@ describe LinuxAdmin::SystemdService do
 
   describe "#running?" do
     it "checks service" do
-      expect(@service).to receive(:run)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(status foo)}).and_return(double(:exit_status => 0))
       @service.running?
     end
 
     it "returns true when service is running" do
-      expect(@service).to receive(:run).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
       expect(@service).to be_running
     end
 
     it "returns false when service is not running" do
-      expect(@service).to receive(:run).and_return(double(:exit_status => 1))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
       expect(@service).not_to be_running
     end
   end
 
   describe "#enable" do
     it "enables service" do
-      expect(@service).to receive(:run!)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(enable foo)})
       @service.enable
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!) # stub out cmd invocation
+      expect(LinuxAdmin::Common).to receive(:run!) # stub out cmd invocation
       expect(@service.enable).to eq(@service)
     end
   end
 
   describe "#disable" do
     it "disables service" do
-      expect(@service).to receive(:run!)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(disable foo)})
       @service.disable
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.disable).to eq(@service)
     end
   end
 
   describe "#start" do
     it "starts service" do
-      expect(@service).to receive(:run!)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(start foo)})
       @service.start
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.start).to eq(@service)
     end
   end
 
   describe "#stop" do
     it "stops service" do
-      expect(@service).to receive(:run!)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(stop foo)})
       @service.stop
     end
 
     it "returns self" do
-      expect(@service).to receive(:run!)
+      expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.stop).to eq(@service)
     end
   end
 
   describe "#restart" do
     it "restarts service" do
-      expect(@service).to receive(:run)
-        .with(@service.cmd(:systemctl),
+      expect(LinuxAdmin::Common).to receive(:run)
+        .with(LinuxAdmin::Common.cmd(:systemctl),
               :params => {nil => %w(restart foo)}).and_return(double(:exit_status => 0))
       @service.restart
     end
 
     it "manually stops then starts service when restart fails" do
-      expect(@service).to receive(:run).and_return(double(:exit_status => 1))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
       expect(@service).to receive(:stop)
       expect(@service).to receive(:start)
       @service.restart
     end
 
     it "returns self" do
-      expect(@service).to receive(:run).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
       expect(@service.restart).to eq(@service)
     end
   end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -49,6 +49,6 @@ describe LinuxAdmin::Service do
   end
 
   def stub_to_service_type(system)
-    allow(LinuxAdmin::Service).to receive(:cmd?).with(:systemctl).and_return(system == :systemd_service)
+    allow(LinuxAdmin::Common).to receive(:cmd?).with(:systemctl).and_return(system == :systemd_service)
   end
 end

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -1,18 +1,14 @@
 describe LinuxAdmin::System do
   describe "#reboot!" do
     it "reboots the system" do
-      expect(LinuxAdmin::System).to receive(:run!).
-         with(LinuxAdmin::System.cmd(:shutdown),
-              :params => { '-r' => 'now'})
+      expect(LinuxAdmin::Common).to receive(:run!).with(LinuxAdmin::Common.cmd(:shutdown), :params => {'-r' => 'now'})
       LinuxAdmin::System.reboot!
     end
   end
 
   describe "#shutdown!" do
     it "shuts down the system" do
-      expect(LinuxAdmin::System).to receive(:run!).
-         with(LinuxAdmin::System.cmd(:shutdown),
-              :params => { '-h' => '0'})
+      expect(LinuxAdmin::Common).to receive(:run!).with(LinuxAdmin::Common.cmd(:shutdown), :params => {'-h' => '0'})
       LinuxAdmin::System.shutdown!
     end
   end

--- a/spec/time_date_spec.rb
+++ b/spec/time_date_spec.rb
@@ -1,5 +1,5 @@
 describe LinuxAdmin::TimeDate do
-  RUN_COMMAND = described_class.cmd("timedatectl")
+  RUN_COMMAND = LinuxAdmin::Common.cmd("timedatectl")
 
   def timedatectl_result
     output = File.read(Pathname.new(data_file_path("time_date/timedatectl_output")))

--- a/spec/volume_group_spec.rb
+++ b/spec/volume_group_spec.rb
@@ -16,16 +16,15 @@ eos
     it "uses lvextend" do
       vg = described_class.new :name => 'vg'
       lv = LinuxAdmin::LogicalVolume.new :name => 'lv', :volume_group => vg
-      expect(vg).to receive(:run!).
-         with(vg.cmd(:lvextend),
-              :params => ['lv', 'vg'])
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:lvextend), :params => %w(lv vg))
       vg.attach_to(lv)
     end
 
     it "returns self" do
       vg = described_class.new :name => 'vg'
       lv = LinuxAdmin::LogicalVolume.new :name => 'lv', :volume_group => vg
-      allow(vg).to receive(:run!)
+      allow(LinuxAdmin::Common).to receive(:run!)
       expect(vg.attach_to(lv)).to eq(vg)
     end
   end
@@ -34,16 +33,15 @@ eos
     it "uses vgextend" do
       vg = described_class.new :name => 'vg'
       pv = LinuxAdmin::PhysicalVolume.new :device_name => '/dev/hda'
-      expect(vg).to receive(:run!).
-         with(vg.cmd(:vgextend),
-              :params => ['vg', '/dev/hda'])
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:vgextend), :params => ['vg', '/dev/hda'])
       vg.extend_with(pv)
     end
 
     it "assigns volume group to physical volume" do
       vg = described_class.new :name => 'vg'
       pv = LinuxAdmin::PhysicalVolume.new :device_name => '/dev/hda'
-      allow(vg).to receive(:run!)
+      allow(LinuxAdmin::Common).to receive(:run!)
       vg.extend_with(pv)
       expect(pv.volume_group).to eq(vg)
     end
@@ -51,7 +49,7 @@ eos
     it "returns self" do
       vg = described_class.new :name => 'vg'
       pv = LinuxAdmin::PhysicalVolume.new :device_name => '/dev/hda'
-      allow(vg).to receive(:run!)
+      allow(LinuxAdmin::Common).to receive(:run!)
       expect(vg.extend_with(pv)).to eq(vg)
     end
   end
@@ -63,21 +61,20 @@ eos
 
     it "uses vgcreate" do
       described_class.instance_variable_set(:@vgs, [])
-      expect(described_class).to receive(:run!).
-                              with(LinuxAdmin.cmd(:vgcreate),
-                                   :params => ['vg', '/dev/hda'])
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:vgcreate), :params => ['vg', '/dev/hda'])
       described_class.create 'vg', @pv
     end
 
     it "returns new volume group" do
-      allow(described_class).to receive_messages(:run! => double(:output => ""))
+      allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
       vg = described_class.create 'vg', @pv
       expect(vg).to be_an_instance_of(described_class)
       expect(vg.name).to eq('vg')
     end
 
     it "adds volume group to local registry" do
-      allow(described_class).to receive_messages(:run! => double(:output => ""))
+      allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
       vg = described_class.create 'vg', @pv
       expect(described_class.scan).to include(vg)
     end
@@ -85,15 +82,14 @@ eos
 
   describe "#scan" do
     it "uses vgdisplay" do
-      expect(described_class).to receive(:run!).
-                              with(LinuxAdmin.cmd(:vgdisplay),
-                                   :params => { '-c' => nil}).
-                                 and_return(double(:output => @groups))
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:vgdisplay), :params => {'-c' => nil})
+        .and_return(double(:output => @groups))
       described_class.scan
     end
 
     it "returns local volume groups" do
-      expect(described_class).to receive(:run!).and_return(double(:output => @groups))
+      expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @groups))
       vgs = described_class.scan
 
       expect(vgs[0]).to be_an_instance_of(described_class)

--- a/spec/yum_spec.rb
+++ b/spec/yum_spec.rb
@@ -5,19 +5,21 @@ describe LinuxAdmin::Yum do
 
   context ".create_repo" do
     it "default arguments" do
-      expect(described_class).to receive(:run!).once.with("createrepo", {:params=>{nil=>"some/path", "--database"=>nil, "--unique-md-filenames"=>nil}})
+      expect(LinuxAdmin::Common).to receive(:run!).once
+        .with("createrepo", :params => {nil => "some/path", "--database" => nil, "--unique-md-filenames" => nil})
       described_class.create_repo("some/path")
     end
 
     it "bare create" do
-      expect(described_class).to receive(:run!).once.with("createrepo", {:params=>{nil=>"some/path"}})
+      expect(LinuxAdmin::Common).to receive(:run!).once.with("createrepo", :params => {nil => "some/path"})
       described_class.create_repo("some/path", :database => false, :unique_file_names => false)
     end
   end
 
   context ".download_packages" do
     it "with valid input" do
-      expect(described_class).to receive(:run!).once.with("repotrack", {:params=>{"-p"=>"some/path", nil=>"pkg_a pkg_b"}})
+      expect(LinuxAdmin::Common).to receive(:run!).once
+        .with("repotrack", :params => {"-p" => "some/path", nil => "pkg_a pkg_b"})
       described_class.download_packages("some/path", "pkg_a pkg_b")
     end
 
@@ -66,45 +68,49 @@ describe LinuxAdmin::Yum do
 
   context ".updates_available?" do
     it "check updates for a specific package" do
-      expect(described_class).to receive(:run).once.with("yum check-update", {:params=>{nil=>["abc"]}}).and_return(double(:exit_status => 100))
+      expect(LinuxAdmin::Common).to receive(:run).once.with("yum check-update", :params => {nil => ["abc"]})
+        .and_return(double(:exit_status => 100))
       expect(described_class.updates_available?("abc")).to be_truthy
     end
 
     it "updates are available" do
-      allow(described_class).to receive_messages(:run => double(:exit_status => 100))
+      allow(LinuxAdmin::Common).to receive_messages(:run => double(:exit_status => 100))
       expect(described_class.updates_available?).to be_truthy
     end
 
     it "updates not available" do
-      allow(described_class).to receive_messages(:run => double(:exit_status => 0))
+      allow(LinuxAdmin::Common).to receive_messages(:run => double(:exit_status => 0))
       expect(described_class.updates_available?).to be_falsey
     end
 
     it "other exit code" do
-      allow(described_class).to receive_messages(:run => double(:exit_status => 255))
+      allow(LinuxAdmin::Common).to receive_messages(:run => double(:exit_status => 255))
       expect { described_class.updates_available? }.to raise_error(RuntimeError)
     end
 
     it "other error" do
-      allow(described_class).to receive(:run).and_raise(RuntimeError)
+      allow(LinuxAdmin::Common).to receive(:run).and_raise(RuntimeError)
       expect { described_class.updates_available? }.to raise_error(RuntimeError)
     end
   end
 
   context ".update" do
     it "no arguments" do
-      expect(described_class).to receive(:run!).once.with("yum -y update", :params => nil).and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
+      expect(LinuxAdmin::Common).to receive(:run!).once.with("yum -y update", :params => nil)
+        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
       described_class.update
     end
 
     it "with arguments" do
-      expect(described_class).to receive(:run!).once.with("yum -y update", :params => {nil => ["1 2", "3"]}).and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
+      expect(LinuxAdmin::Common).to receive(:run!).once.with("yum -y update", :params => {nil => ["1 2", "3"]})
+        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
       described_class.update("1 2", "3")
     end
 
     it "with bad arguments" do
       error = AwesomeSpawn::CommandResult.new("", "Loaded plugins: product-id\nNo Packages marked for Update\n", "Blah blah ...\nNo Match for argument: \n", 0)
-      expect(described_class).to receive(:run!).once.with("yum -y update", :params => {nil => [""]}).and_return(error)
+      expect(LinuxAdmin::Common).to receive(:run!).once
+        .with("yum -y update", :params => {nil => [""]}).and_return(error)
       expect { described_class.update("") }.to raise_error(AwesomeSpawn::CommandResultError)
     end
   end
@@ -115,12 +121,16 @@ describe LinuxAdmin::Yum do
     end
 
     it "with one package" do
-      expect(described_class).to receive(:run!).once.with("repoquery --qf=\"%{name} %{version}\"", {:params=>{nil=>["subscription-manager"]}}).and_return(double(:output => sample_output("yum/output_repoquery_single")))
+      expect(LinuxAdmin::Common).to receive(:run!).once
+        .with("repoquery --qf=\"%{name} %{version}\"", :params => {nil => ["subscription-manager"]})
+        .and_return(double(:output => sample_output("yum/output_repoquery_single")))
       expect(described_class.version_available("subscription-manager")).to eq({"subscription-manager" => "1.1.23.1"})
     end
 
     it "with multiple packages" do
-      expect(described_class).to receive(:run!).once.with("repoquery --qf=\"%{name} %{version}\"", {:params=>{nil=>["curl", "subscription-manager", "wget"]}}).and_return(double(:output => sample_output("yum/output_repoquery_multiple")))
+      expect(LinuxAdmin::Common).to receive(:run!).once
+        .with("repoquery --qf=\"%{name} %{version}\"", :params => {nil => ["curl", "subscription-manager", "wget"]})
+        .and_return(double(:output => sample_output("yum/output_repoquery_multiple")))
       expect(described_class.version_available("curl", "subscription-manager", "wget")).to eq({
         "curl"                  => "7.19.7",
         "subscription-manager"  => "1.1.23.1",
@@ -131,12 +141,14 @@ describe LinuxAdmin::Yum do
 
   context ".repo_list" do
     it "with no arguments" do
-      expect(described_class).to receive(:run!).with("yum repolist", {:params=>{nil=>"enabled"}}).and_return(double(:output => sample_output("yum/output_repo_list")))
+      expect(LinuxAdmin::Common).to receive(:run!).with("yum repolist", :params => {nil => "enabled"})
+        .and_return(double(:output => sample_output("yum/output_repo_list")))
       expect(described_class.repo_list).to eq(["rhel-6-server-rpms", "rhel-ha-for-rhel-6-server-rpms", "rhel-lb-for-rhel-6-server-rpms"])
     end
 
     it "with argument" do
-      expect(described_class).to receive(:run!).with("yum repolist", {:params=>{nil=>"enabled"}}).and_return(double(:output => sample_output("yum/output_repo_list")))
+      expect(LinuxAdmin::Common).to receive(:run!).with("yum repolist", :params => {nil => "enabled"})
+        .and_return(double(:output => sample_output("yum/output_repo_list")))
       expect(described_class.repo_list("enabled")).to eq(["rhel-6-server-rpms", "rhel-ha-for-rhel-6-server-rpms", "rhel-lb-for-rhel-6-server-rpms"])
     end
   end


### PR DESCRIPTION
Previously nearly all classes were mixing in LinuxAdmin::Common
to get access to what really are just utility methods.

Not sure when a good time to make this sort of change is, but I'm giving it a shot.
@bdunne @Fryguy @jrafanie 

Fixes #19