### PR TITLE
add rubocop to Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+bin

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -33,6 +33,7 @@ registration, updates, etc.
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",    "~> 3.0"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rubocop"
 
   spec.add_dependency "activesupport",        "> 3.2"
   spec.add_dependency "inifile"


### PR DESCRIPTION
I use bundle exec to run commands

The bot is running `rubocops` on these. So, state `rubocop` as a dependency. (at least in the local `Gemfile`)