### PR TITLE
trim down service calls and add mac support

### DIFF
--- a/lib/linux_admin/service.rb
+++ b/lib/linux_admin/service.rb
@@ -32,7 +32,14 @@ module LinuxAdmin
     private
 
     def self.service_type_uncached
-      Common.cmd?(:systemctl) ? SystemdService : SysVInitService
+      {
+        :systemctl => SystemdService,
+        :service   => SysVInitService,
+        :brew      => BrewService,
+      }.each do |key, service|
+        return service if Common.cmd?(key)
+      end
+      nil
     end
     private_class_method :service_type_uncached
   end

--- a/lib/linux_admin/service/brew_service.rb
+++ b/lib/linux_admin/service/brew_service.rb
@@ -1,0 +1,54 @@
+# s = LinuxAdmin::Service.new("postgresql")
+begin
+  require 'bundler'
+rescue LoaderException
+end
+
+module LinuxAdmin
+  class BrewService < Service
+    def running?
+      # brew services list shows all the services running / installed
+      ::Bundler.with_clean_env {
+        Common.run(Common.cmd(:brew), :params => %w(services list))
+          .output.split("\n").any? { |x| x.starts_with?("#{name} ") }
+      }
+    end
+
+    def enable
+      run_cmd!("start", name)
+    end
+
+    def disable
+      run_cmd!("stop", name)
+    end
+
+    def start
+      run_cmd!("start", name)
+    end
+
+    def stop
+      run_cmd!("stop", name)
+    end
+
+    def restart
+      # attempt to manually stop/start if restart fails
+      unless run_cmd("restart", name)
+        stop
+        start
+      end
+
+      self
+    end
+
+    private
+
+    def run_cmd(*actions)
+      ::Bundler.with_clean_env { Common.run(Common.cmd(:brew), :params => %w(services) + actions).success? }
+    end
+
+    def run_cmd!(*actions)
+      ::Bundler.with_clean_env { Common.run!(Common.cmd(:brew), :params => %w(services) + actions) }
+      self
+    end
+  end
+end

--- a/lib/linux_admin/service/sys_v_init_service.rb
+++ b/lib/linux_admin/service/sys_v_init_service.rb
@@ -1,45 +1,45 @@
 module LinuxAdmin
   class SysVInitService < Service
     def running?
-      Common.run(Common.cmd(:service),
-                 :params => {nil => [name, "status"]}).exit_status == 0
+      run_cmd(name, "status")
     end
 
     def enable
-      Common.run!(Common.cmd(:chkconfig),
-                  :params => {nil => [name, "on"]})
+      Common.run!(Common.cmd(:chkconfig), :params => [name, "on"])
       self
     end
 
     def disable
-      Common.run!(Common.cmd(:chkconfig),
-                  :params => {nil => [name, "off"]})
+      Common.run!(Common.cmd(:chkconfig), :params => [name, "off"])
       self
     end
 
     def start
-      Common.run!(Common.cmd(:service),
-                  :params => {nil => [name, "start"]})
-      self
+      run_cmd!(name, "start")
     end
 
     def stop
-      Common.run!(Common.cmd(:service),
-                  :params => {nil => [name, "stop"]})
-      self
+      run_cmd!(name, "stop")
     end
 
     def restart
-      status =
-        Common.run(Common.cmd(:service),
-                   :params => {nil => [name, "restart"]}).exit_status
-
       # attempt to manually stop/start if restart fails
-      if status != 0
+      unless run_cmd(name, "restart")
         self.stop
         self.start
       end
 
+      self
+    end
+
+    private
+
+    def run_cmd(*actions)
+      Common.run(Common.cmd(:service), :params => actions).success?
+    end
+
+    def run_cmd!(*actions)
+      Common.run!(Common.cmd(:service), :params => actions)
       self
     end
   end

--- a/lib/linux_admin/service/systemd_service.rb
+++ b/lib/linux_admin/service/systemd_service.rb
@@ -1,45 +1,43 @@
 module LinuxAdmin
   class SystemdService < Service
     def running?
-      Common.run(Common.cmd(:systemctl),
-                 :params => {nil => ["status", name]}).exit_status == 0
+      run_cmd("status", name)
     end
 
     def enable
-      Common.run!(Common.cmd(:systemctl),
-                  :params => {nil => ["enable", name]})
-      self
+      run_cmd!("enable", name)
     end
 
     def disable
-      Common.run!(Common.cmd(:systemctl),
-                  :params => {nil => ["disable", name]})
-      self
+      run_cmd!("disable", name)
     end
 
     def start
-      Common.run!(Common.cmd(:systemctl),
-                  :params => {nil => ["start", name]})
-      self
+      run_cmd!("start", name)
     end
 
     def stop
-      Common.run!(Common.cmd(:systemctl),
-                  :params => {nil => ["stop", name]})
-      self
+      run_cmd!("stop", name)
     end
 
     def restart
-      status =
-        Common.run(Common.cmd(:systemctl),
-                   :params => {nil => ["restart", name]}).exit_status
-
       # attempt to manually stop/start if restart fails
-      if status != 0
+      unless run_cmd("restart", name)
         stop
         start
       end
 
+      self
+    end
+
+    private
+
+    def run_cmd(*actions)
+      Common.run(Common.cmd(:systemctl), :params => actions).success?
+    end
+
+    def run_cmd!(*actions)
+      Common.run!(Common.cmd(:systemctl), :params => actions)
       self
     end
   end

--- a/spec/service/brew_service_spec.rb
+++ b/spec/service/brew_service_spec.rb
@@ -1,31 +1,38 @@
-describe LinuxAdmin::SystemdService do
+describe LinuxAdmin::BrewService do
   before do
     @service = described_class.new 'foo'
-    allow(LinuxAdmin::Common).to receive(:cmd).with(:systemctl).and_return("systemctl")
+    allow(LinuxAdmin::Common).to receive(:cmd).with(:brew).and_return("brew")
   end
 
   describe "#running?" do
     it "checks service" do
       expect(LinuxAdmin::Common).to receive(:run)
-        .with("systemctl",
-              :params => %w(status foo)).and_return(double(:success? => true))
+        .with("brew",
+              :params => %w(services list)).and_return(double(:output => "foo params running\nother param running\n"))
       @service.running?
     end
 
     it "returns true when service is running" do
-      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => true))
+      expect(LinuxAdmin::Common).to receive(:run)
+        .and_return(double(:output => "foo  param file\nother params running\n"))
       expect(@service).to be_running
     end
 
     it "returns false when service is not running" do
-      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => false))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:output => "other\n"))
+      expect(@service).not_to be_running
+    end
+
+    it "returns false when service is not running (even though name is close" do
+      expect(LinuxAdmin::Common).to receive(:run)
+        .and_return(double(:output => "foo2 param running\nother param running\n"))
       expect(@service).not_to be_running
     end
   end
 
   describe "#enable" do
     it "enables service" do
-      expect(LinuxAdmin::Common).to receive(:run!).with("systemctl", :params => %w(enable foo))
+      expect(LinuxAdmin::Common).to receive(:run!).with("brew", :params => %w(services start foo))
       @service.enable
     end
 
@@ -36,8 +43,8 @@ describe LinuxAdmin::SystemdService do
   end
 
   describe "#disable" do
-    it "disables service" do
-      expect(LinuxAdmin::Common).to receive(:run!).with("systemctl", :params => %w(disable foo))
+    it "stops the service" do
+      expect(LinuxAdmin::Common).to receive(:run!).with("brew", :params => %w(services stop foo))
       @service.disable
     end
 
@@ -49,7 +56,7 @@ describe LinuxAdmin::SystemdService do
 
   describe "#start" do
     it "starts service" do
-      expect(LinuxAdmin::Common).to receive(:run!).with("systemctl", :params => %w(start foo))
+      expect(LinuxAdmin::Common).to receive(:run!).with("brew", :params => %w(services start foo))
       @service.start
     end
 
@@ -61,7 +68,7 @@ describe LinuxAdmin::SystemdService do
 
   describe "#stop" do
     it "stops service" do
-      expect(LinuxAdmin::Common).to receive(:run!).with("systemctl", :params => %w(stop foo))
+      expect(LinuxAdmin::Common).to receive(:run!).with("brew", :params => %w(services stop foo))
       @service.stop
     end
 
@@ -74,8 +81,7 @@ describe LinuxAdmin::SystemdService do
   describe "#restart" do
     it "restarts service" do
       expect(LinuxAdmin::Common).to receive(:run)
-        .with("systemctl",
-              :params => %w(restart foo)).and_return(double(:success? => true))
+        .with("brew", :params => %w(services restart foo)).and_return(double(:success? => true))
       @service.restart
     end
 

--- a/spec/service/sys_v_init_service_spec.rb
+++ b/spec/service/sys_v_init_service_spec.rb
@@ -1,20 +1,21 @@
 describe LinuxAdmin::SysVInitService do
   before do
     @service = described_class.new 'foo'
+    allow(LinuxAdmin::Common).to receive(:cmd).with(:service).and_return("service")
+    allow(LinuxAdmin::Common).to receive(:cmd).with(:chkconfig).and_return("chkconfig")
   end
 
   describe "#running?" do
     it "checks service" do
       expect(LinuxAdmin::Common).to receive(:run)
-        .with(LinuxAdmin::Common.cmd(:service),
-              :params => {nil => %w(foo status)}).and_return(double(:exit_status => 0))
+        .with("service", :params => %w(foo status)).and_return(double(:success? => true))
       @service.running?
     end
 
     context "service is running" do
       it "returns true" do
         @service = described_class.new :id => :foo
-        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => true))
         expect(@service).to be_running
       end
     end
@@ -22,7 +23,7 @@ describe LinuxAdmin::SysVInitService do
     context "service is not running" do
       it "returns false" do
         @service = described_class.new :id => :foo
-        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => false))
         expect(@service).not_to be_running
       end
     end
@@ -30,9 +31,7 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#enable" do
     it "enables service" do
-      expect(LinuxAdmin::Common).to receive(:run!)
-        .with(LinuxAdmin::Common.cmd(:chkconfig),
-              :params => {nil => %w(foo on)})
+      expect(LinuxAdmin::Common).to receive(:run!).with("chkconfig", :params => %w(foo on))
       @service.enable
     end
 
@@ -44,9 +43,7 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#disable" do
     it "disable service" do
-      expect(LinuxAdmin::Common).to receive(:run!)
-        .with(LinuxAdmin::Common.cmd(:chkconfig),
-              :params => {nil => %w(foo off)})
+      expect(LinuxAdmin::Common).to receive(:run!).with("chkconfig", :params => %w(foo off))
       @service.disable
     end
 
@@ -58,9 +55,7 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#start" do
     it "starts service" do
-      expect(LinuxAdmin::Common).to receive(:run!)
-        .with(LinuxAdmin::Common.cmd(:service),
-              :params => {nil => %w(foo start)})
+      expect(LinuxAdmin::Common).to receive(:run!).with("service", :params => %w(foo start))
       @service.start
     end
 
@@ -72,9 +67,7 @@ describe LinuxAdmin::SysVInitService do
 
   describe "#stop" do
     it "stops service" do
-      expect(LinuxAdmin::Common).to receive(:run!)
-        .with(LinuxAdmin::Common.cmd(:service),
-              :params => {nil => %w(foo stop)})
+      expect(LinuxAdmin::Common).to receive(:run!).with("service", :params => %w(foo stop))
       @service.stop
     end
 
@@ -87,14 +80,13 @@ describe LinuxAdmin::SysVInitService do
   describe "#restart" do
     it "stops service" do
       expect(LinuxAdmin::Common).to receive(:run)
-        .with(LinuxAdmin::Common.cmd(:service),
-              :params => {nil => %w(foo restart)}).and_return(double(:exit_status => 0))
+        .with("service", :params => %w(foo restart)).and_return(double(:success? => true))
       @service.restart
     end
 
     context "service restart fails" do
       it "manually stops/starts service" do
-        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 1))
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => false))
         expect(@service).to receive(:stop)
         expect(@service).to receive(:start)
         @service.restart
@@ -102,7 +94,7 @@ describe LinuxAdmin::SysVInitService do
     end
 
     it "returns self" do
-      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:success? => true))
       expect(@service.restart).to eq(@service)
     end
   end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -10,6 +10,11 @@ describe LinuxAdmin::Service do
       expect(described_class.service_type).to eq(LinuxAdmin::SysVInitService)
     end
 
+    it "on sysv systems" do
+      stub_to_service_type(:brew_service)
+      expect(described_class.service_type).to eq(LinuxAdmin::BrewService)
+    end
+
     it "should memoize results" do
       expect(described_class).to receive(:service_type_uncached).once.and_return("anything_non_nil")
       described_class.service_type
@@ -33,6 +38,11 @@ describe LinuxAdmin::Service do
       stub_to_service_type(:sys_v_init_service)
       expect(described_class.new("xxx")).to be_kind_of(LinuxAdmin::SysVInitService)
     end
+
+    it "on mac systems" do
+      stub_to_service_type(:brew_service)
+      expect(described_class.new("xxx")).to be_kind_of(LinuxAdmin::BrewService)
+    end
   end
 
   it "#id / #id=" do
@@ -50,5 +60,7 @@ describe LinuxAdmin::Service do
 
   def stub_to_service_type(system)
     allow(LinuxAdmin::Common).to receive(:cmd?).with(:systemctl).and_return(system == :systemd_service)
+    allow(LinuxAdmin::Common).to receive(:cmd?).with(:service).and_return(system == :sys_v_init_service)
+    allow(LinuxAdmin::Common).to receive(:cmd?).with(:brew).and_return(system == :brew_service)
   end
 end


### PR DESCRIPTION
reduce duplicate code for `LinuxAdmin::Service`

add support for the mac as well.

/cc @carbonin this is related to ManageIQ/manageiq#6208
