### PR TITLE
Update more_core_extensions to 2.0

### DIFF
--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -36,7 +36,7 @@ registration, updates, etc.
 
   spec.add_dependency "activesupport",        "> 3.2"
   spec.add_dependency "inifile"
-  spec.add_dependency "more_core_extensions", "~> 1.1"
+  spec.add_dependency "more_core_extensions", "~> 2.0"
   spec.add_dependency "awesome_spawn",        "~> 1.3"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openscap"


### PR DESCRIPTION
`more_core_extensions` 2.0.0 is out, is there any reason `linux_admin` is still depending on 1.*?

We.. may need a new release for this, because of ManageIQ/manageiq#6360.

Judging by the [more_core_extensions changes](https://github.com/ManageIQ/more_core_extensions/commit/28b063eae2cbf6a4b8112d8a030ed560ca45db80), this should not break anything (no `#namespace` or `#include_any?` in `linux_admin`).