### PR TITLE
Drop activesupport dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-- "1.9.3"
 - "2.0"
 - "2.1"
-- "2.2"
+- "2.2.5"
+- "2.3.1"
 - ruby-head
 - jruby-head
 sudo: false

--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -1,6 +1,4 @@
 require 'more_core_extensions/all'
-require 'active_support'
-require 'active_support/core_ext'
 
 require 'linux_admin/logging'
 require 'linux_admin/null_logger'

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -13,21 +13,25 @@ module LinuxAdmin
     def str_to_bytes(val, unit)
       case unit
       when 'K' then
-        val.to_f.kilobytes
+        val.to_f * 1_024 # 1.kilobytes
       when 'M' then
-        val.to_f.megabytes
+        val.to_f * 1_048_576 # 1.megabyte
       when 'G' then
-        val.to_f.gigabytes
+        val.to_f * 1_073_741_824 # 1.gigabytes
       end
     end
-    
+
     def overlapping_ranges?(ranges)
       ranges.find do |range1|
         ranges.any? do |range2|
           range1 != range2 &&
-          range1.overlaps?(range2)
+            ranges_overlap?(range1, range2)
         end
       end
+    end
+
+    def ranges_overlap?(range1, range2) # copied from activesupport Range#overlaps?
+      range1.cover?(range2.first) || range2.cover?(range1.first)
     end
 
     def check_if_partitions_overlap(partitions)

--- a/lib/linux_admin/logging.rb
+++ b/lib/linux_admin/logging.rb
@@ -1,5 +1,7 @@
 module LinuxAdmin
   module Logging
-    delegate :logger, :to => :LinuxAdmin
+    def logger
+      LinuxAdmin.logger
+    end
   end
 end

--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -57,12 +57,12 @@ module LinuxAdmin
     private
 
     def self.bytes_to_string(bytes)
-      if bytes > 1.gigabytes
-        (bytes / 1.gigabytes).to_s + "G"
-      elsif bytes > 1.megabytes
-        (bytes / 1.megabytes).to_s + "M"
-      elsif bytes > 1.kilobytes
-        (bytes / 1.kilobytes).to_s + "K"
+      if bytes > 1_073_741_824 # 1.gigabytes
+        (bytes / 1_073_741_824).to_s + "G"
+      elsif bytes > 1_048_576 # 1.megabytes
+        (bytes / 1_048_576).to_s + "M"
+      elsif bytes > 1_024 # 1.kilobytes
+        (bytes / 1_024).to_s + "K"
       else
         bytes.to_s
       end

--- a/lib/linux_admin/registration_system/subscription_manager.rb
+++ b/lib/linux_admin/registration_system/subscription_manager.rb
@@ -34,7 +34,7 @@ module LinuxAdmin
       params.merge!(proxy_params(options))
 
       result = run!(cmd, :params => params)
-      parse_output(result.output).index_by {|i| i[:name]}
+      parse_output(result.output).each_with_object({}) { |i, h| h[i[:name]] = i }
     end
 
     def register(options)
@@ -76,7 +76,7 @@ module LinuxAdmin
     def available_subscriptions
       cmd     = "subscription-manager list --all --available"
       output  = run!(cmd).output
-      parse_output(output).index_by {|i| i[:pool_id]}
+      parse_output(output).each_with_object({}) { |i, h| h[i[:pool_id]] = i }
     end
 
     def enable_repo(repo, options = nil)

--- a/lib/linux_admin/yum.rb
+++ b/lib/linux_admin/yum.rb
@@ -5,7 +5,7 @@ module LinuxAdmin
   class Yum
     def self.create_repo(path, options = {})
       raise ArgumentError, "path is required" unless path
-      options = options.reverse_merge(:database => true, :unique_file_names => true)
+      options = {:database => true, :unique_file_names => true}.merge(options)
 
       FileUtils.mkdir_p(path)
 
@@ -20,7 +20,7 @@ module LinuxAdmin
     def self.download_packages(path, packages, options = {})
       raise ArgumentError, "path is required"       unless path
       raise ArgumentError, "packages are required"  unless packages
-      options = options.reverse_merge(:mirror_type => :package)
+      options = {:mirror_type => :package}.merge(options)
 
       FileUtils.mkdir_p(path)
 

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -35,10 +35,9 @@ registration, updates, etc.
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "rubocop"
 
-  spec.add_dependency "activesupport",        "> 3.2"
-  spec.add_dependency "inifile"
-  spec.add_dependency "more_core_extensions", "~> 2.0"
   spec.add_dependency "awesome_spawn",        "~> 1.3"
+  spec.add_dependency "inifile"
+  spec.add_dependency "more_core_extensions", "~> 3.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openscap"
 end

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -27,7 +27,7 @@ registration, updates, etc.
   spec.test_files    = `git ls-files -- spec/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_development_dependency "bundler",  "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -74,23 +74,23 @@ eos
 
       expect(disk.partitions[0].id).to eq(1)
       expect(disk.partitions[0].disk).to eq(disk)
-      expect(disk.partitions[0].size).to eq(80.5.gigabytes)
-      expect(disk.partitions[0].start_sector).to eq(1259.megabytes)
-      expect(disk.partitions[0].end_sector).to eq(81.8.gigabytes)
+      expect(disk.partitions[0].size).to eq(86_436_216_832.0) # 80.5.gigabytes
+      expect(disk.partitions[0].start_sector).to eq(1_320_157_184) # 1259.megabytes
+      expect(disk.partitions[0].end_sector).to eq(87_832_081_203.2) # 81.8.gigabytes
       expect(disk.partitions[0].partition_type).to eq('primary')
       expect(disk.partitions[0].fs_type).to eq('ntfs')
       expect(disk.partitions[1].id).to eq(2)
       expect(disk.partitions[1].disk).to eq(disk)
-      expect(disk.partitions[1].size).to eq(80.5.gigabytes)
-      expect(disk.partitions[1].start_sector).to eq(81.8.gigabytes)
-      expect(disk.partitions[1].end_sector).to eq(162.gigabytes)
+      expect(disk.partitions[1].size).to eq(86_436_216_832.0) # 80.5.gigabytes
+      expect(disk.partitions[1].start_sector).to eq(87_832_081_203.2) # 81.8.gigabytes
+      expect(disk.partitions[1].end_sector).to eq(173_946_175_488) # 162.gigabytes
       expect(disk.partitions[1].partition_type).to eq('primary')
       expect(disk.partitions[1].fs_type).to eq('ext4')
       expect(disk.partitions[2].id).to eq(3)
       expect(disk.partitions[2].disk).to eq(disk)
-      expect(disk.partitions[2].size).to eq(1074.megabytes)
-      expect(disk.partitions[2].start_sector).to eq(162.gigabytes)
-      expect(disk.partitions[2].end_sector).to eq(163.gigabytes)
+      expect(disk.partitions[2].size).to eq(1_126_170_624) # 1074.megabytes
+      expect(disk.partitions[2].start_sector).to eq(173_946_175_488) # 162.gigabytes
+      expect(disk.partitions[2].end_sector).to eq(175_019_917_312) # 163.gigabytes
       expect(disk.partitions[2].partition_type).to eq('logical')
       expect(disk.partitions[2].fs_type).to eq('linux-swap(v1)')
     end

--- a/spec/logical_volume_spec.rb
+++ b/spec/logical_volume_spec.rb
@@ -55,7 +55,7 @@ eos
               :params => {'-n' => 'lv',
                           nil  => 'vg',
                           '-L' => '256G'})
-      described_class.create 'lv', @vg, 256.gigabytes
+      described_class.create 'lv', @vg, 274_877_906_944 # 256.gigabytes
     end
 
     context "size is specified" do
@@ -66,7 +66,7 @@ eos
                 :params => {'-n' => 'lv',
                             nil  => 'vg',
                             '-L' => '256G'})
-        described_class.create 'lv', @vg, 256.gigabytes
+        described_class.create 'lv', @vg, 274_877_906_944 # 256.gigabytes
       end
     end
 
@@ -85,7 +85,7 @@ eos
     it "returns new logical volume" do
       allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
       allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
-      lv = described_class.create 'lv', @vg, 256.gigabytes
+      lv = described_class.create 'lv', @vg, 274_877_906_944 # 256.gigabytes
       expect(lv).to be_an_instance_of(described_class)
       expect(lv.name).to eq('lv')
     end
@@ -94,7 +94,7 @@ eos
       it "sets path under volume group" do
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
-        lv = described_class.create 'lv', @vg, 256.gigabytes
+        lv = described_class.create 'lv', @vg, 274_877_906_944 # 256.gigabytes
         expect(lv.path.to_s).to eq("#{described_class::DEVICE_PATH}#{@vg.name}/lv")
       end
     end
@@ -103,7 +103,7 @@ eos
       it "sets name" do
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
-        lv = described_class.create '/dev/lv', @vg, 256.gigabytes
+        lv = described_class.create '/dev/lv', @vg, 274_877_906_944 # 256.gigabytes
         expect(lv.name).to eq("lv")
       end
     end
@@ -113,7 +113,7 @@ eos
         require 'pathname'
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
         allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
-        lv = described_class.create Pathname.new("/dev/#{@vg.name}/lv"), @vg, 256.gigabytes
+        lv = described_class.create Pathname.new("/dev/#{@vg.name}/lv"), @vg, 274_877_906_944 # 256.gigabytes
         expect(lv.name).to eq("lv")
         expect(lv.path).to eq("/dev/vg/lv")
       end
@@ -122,7 +122,7 @@ eos
     it "adds logical volume to local registry" do
       allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
       allow(LinuxAdmin::Common).to receive_messages(:run! => double(:output => ""))
-      lv = described_class.create 'lv', @vg, 256.gigabytes
+      lv = described_class.create 'lv', @vg, 274_877_906_944 # 256.gigabytes
       expect(described_class.scan).to include(lv)
     end
   end


### PR DESCRIPTION
Drop support for Ruby 1.9.3 and test against 2.3.1
Rails 5 isn't compatible with older rubies.
Rather than dropping support for older rubies just for #blank?, we can define #blank? if it isn't already defined.