### PR TITLE
Changed number_of_password_prompts to be 0 in all cases

### DIFF
--- a/lib/linux_admin/ssh.rb
+++ b/lib/linux_admin/ssh.rb
@@ -25,10 +25,9 @@ module LinuxAdmin
 
     def execute_commands(commands, agent_socket, stdin)
       result = nil
-      args = {:paranoid => false}
+      args = {:paranoid => false, :number_of_password_prompts => 0}
       if agent_socket
         args.merge!(:forward_agent              => true,
-                    :number_of_password_prompts => 0,
                     :agent_socket_factory       => -> { UNIXSocket.open(agent_socket) })
       elsif @private_key
         args[:key_data] = [@private_key]

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -42,12 +42,12 @@ sV1Tr/acrE0aWBkD9RYrR2/UwG1zfXuIJeufdWf8c0SY3X6J7jJN
   end
 
   it "should preform command using private key" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :key_data => [@example_ssh_key]).and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :number_of_password_prompts => 0, :key_data => [@example_ssh_key]).and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", @example_ssh_key).perform_commands(%w("ls", "pwd"))
   end
 
   it "should preform command using password" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :password => "password").and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :number_of_password_prompts => 0, :password => "password").and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", nil, "password").perform_commands(%w("ls", "pwd"))
   end
 end


### PR DESCRIPTION
SSH class will give a prompt instead of failing authentication without this attributes.
