### PR TITLE
Improve error message when yum check-update returns error

### DIFF
--- a/lib/linux_admin/yum.rb
+++ b/lib/linux_admin/yum.rb
@@ -43,11 +43,11 @@ module LinuxAdmin
       cmd    = "yum check-update"
       params = {nil => packages} unless packages.blank?
 
-      exitstatus = Common.run(cmd, :params => params).exit_status
-      case exitstatus
+      spawn = Common.run(cmd, :params => params)
+      case spawn.exit_status
       when 0;   false
       when 100; true
-      else raise "Error: Exit Code #{exitstatus}"
+      else raise "Error: #{cmd} returns '#{spawn.exit_status}', '#{spawn.error}'"
       end
     end
 

--- a/spec/yum_spec.rb
+++ b/spec/yum_spec.rb
@@ -84,7 +84,7 @@ describe LinuxAdmin::Yum do
     end
 
     it "other exit code" do
-      allow(LinuxAdmin::Common).to receive_messages(:run => double(:exit_status => 255))
+      allow(LinuxAdmin::Common).to receive_messages(:run => double(:exit_status => 255, :error => 'test'))
       expect { described_class.updates_available? }.to raise_error(RuntimeError)
     end
 


### PR DESCRIPTION
The `yum check-update` will return 1 when the system has connectivity
issues or when the system is not registered with rhn (empty repolist).

Without the improvement, users have low chances to understand what was
the nature of an error, as they may not understand what command was
being run.

Addressing:
https://bugzilla.redhat.com/show_bug.cgi?id=1369556

@miq-bot add_label bug, core