### PR TITLE
Add the ability to discover the mountpoint by device path

### DIFF
--- a/lib/linux_admin/mountable.rb
+++ b/lib/linux_admin/mountable.rb
@@ -18,6 +18,12 @@ module LinuxAdmin
       base.extend(ClassMethods)
     end
 
+    def discover_mount_point
+      result = Common.run!(Common.cmd(:mount))
+      mount_line = result.output.split("\n").find { |line| line.split[0] == path }
+      @mount_point = mount_line.split[2] if mount_line
+    end
+
     def format_to(filesystem)
       Common.run!(Common.cmd(:mke2fs),
                   :params => {'-t' => filesystem, nil => path})

--- a/spec/mountable_spec.rb
+++ b/spec/mountable_spec.rb
@@ -21,6 +21,12 @@ eos
 cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
 systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=26,pgrp=1,timeout=300,minproto=5,maxproto=5,direct)
 eos
+
+    @mount_out3 = <<eos
+/dev/mapper/vg_data-lv_pg on /var/opt/rh/rh-postgresql95/lib/pgsql type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
+/dev/foo on /tmp type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
+/dev/foo on /home type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
+eos
   end
 
   describe "#mount_point_exists?" do
@@ -64,6 +70,20 @@ eos
         expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out2))
         expect(TestMountable.mount_point_available?('/mnt/usb')).to be_truthy
       end
+    end
+  end
+
+  describe "#discover_mount_point" do
+    it "sets the correct mountpoint when the path is mounted" do
+      expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out3))
+      @mountable.discover_mount_point
+      expect(@mountable.mount_point).to eq("/tmp")
+    end
+
+    it "sets mount_point to nil when the path is not mounted" do
+      expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out1))
+      @mountable.discover_mount_point
+      expect(@mountable.mount_point).to be_nil
     end
   end
 


### PR DESCRIPTION
This will allow a user to determine the current mount point of a device using the device path.

This does not handle multiple mount points and will return the first one returned by the `mount` command if a device is mounted multiple times.

@bdunne please review