### PR TITLE
Add a method to list the timezones in TimeDate

### DIFF
--- a/lib/linux_admin/time_date.rb
+++ b/lib/linux_admin/time_date.rb
@@ -15,6 +15,13 @@ module LinuxAdmin
       system_timezone_detailed.split[0]
     end
 
+    def self.timezones
+      result = Common.run!(Common.cmd(COMMAND), :params => ["list-timezones"])
+      result.output.split("\n")
+    rescue AwesomeSpawn::CommandResultError => e
+      raise TimeCommandError, e.message
+    end
+
     def self.system_time=(time)
       Common.run!(Common.cmd(COMMAND), :params => ["set-time", "#{time.strftime("%F %T")}", :adjust_system_clock])
     rescue AwesomeSpawn::CommandResultError => e

--- a/spec/time_date_spec.rb
+++ b/spec/time_date_spec.rb
@@ -30,6 +30,38 @@ describe LinuxAdmin::TimeDate do
     end
   end
 
+  describe ".timezones" do
+    let(:timezones) do
+      <<-EOS
+Africa/Bangui
+Africa/Banjul
+Africa/Bissau
+Africa/Blantyre
+Africa/Brazzaville
+Africa/Bujumbura
+Africa/Cairo
+America/Havana
+America/Hermosillo
+America/Indiana/Indianapolis
+America/Indiana/Knox
+America/Argentina/San_Juan
+America/Argentina/San_Luis
+America/Argentina/Tucuman
+America/Argentina/Ushuaia
+      EOS
+    end
+
+    it "returns the correct list" do
+      awesome_spawn_args = [
+        RUN_COMMAND,
+        :params => ["list-timezones"]
+      ]
+      result = AwesomeSpawn::CommandResult.new("", timezones, "", 0)
+      expect(AwesomeSpawn).to receive(:run!).with(*awesome_spawn_args).and_return(result)
+      expect(described_class.timezones).to eq(timezones.split("\n"))
+    end
+  end
+
   describe ".system_time=" do
     it "sets the time" do
       time = Time.new(2015, 1, 1, 1, 1, 1)


### PR DESCRIPTION
This will accurately show the timezones available for use with `TimeDate.system_timezone=`

Motivated by https://bugzilla.redhat.com/show_bug.cgi?id=1356688