### PR TITLE
Add a method to set the hostname for both IPv6 and IPv4 loopback addr…

### DIFF
--- a/lib/linux_admin/hosts.rb
+++ b/lib/linux_admin/hosts.rb
@@ -26,6 +26,10 @@ module LinuxAdmin
 
     alias_method :update_entry, :add_alias
 
+    def set_loopback_hostname(hostname, comment = nil)
+      ["::1", "127.0.0.1"].each { |address| add_name(address, hostname, true, comment, false) }
+    end
+
     def set_canonical_hostname(address, hostname, comment = nil)
       add_name(address, hostname, true, comment)
     end
@@ -46,9 +50,9 @@ module LinuxAdmin
 
     private
 
-    def add_name(address, hostname, fqdn, comment)
+    def add_name(address, hostname, fqdn, comment, remove_existing = true)
       # Delete entries for this hostname first
-      @parsed_file.each { |i| i[:hosts].to_a.delete(hostname) }
+      @parsed_file.each { |i| i[:hosts].to_a.delete(hostname) } if remove_existing
 
       # Add entry
       line_number = @parsed_file.find_path(address).first

--- a/spec/hosts_spec.rb
+++ b/spec/hosts_spec.rb
@@ -32,6 +32,35 @@ describe LinuxAdmin::Hosts do
     end
   end
 
+  describe "#set_loopback_hostname" do
+    etc_hosts_v6_loopback = <<-EOT
+
+#Some Comment
+::1\tlocalhost localhost.localdomain # with a comment
+127.0.0.1\tlocalhost localhost.localdomain # with a comment
+127.0.1.1  my.domain.local
+EOT
+
+    before do
+      allow(File).to receive(:read).and_return(etc_hosts_v6_loopback)
+      @instance_v6_loopback = LinuxAdmin::Hosts.new
+    end
+
+    it "adds the hostname to the start of the hosts list for the loopback addresses" do
+      expected_hash = [{:blank   => true},
+                       {:comment => "Some Comment"},
+                       {:address => "::1",
+                        :hosts   => ["examplehost.example.com", "localhost", "localhost.localdomain"],
+                        :comment => "with a comment"},
+                       {:address => "127.0.0.1",
+                        :hosts   => ["examplehost.example.com", "localhost", "localhost.localdomain"],
+                        :comment => "with a comment"},
+                       {:address => "127.0.1.1", :hosts => ["my.domain.local"]}]
+      @instance_v6_loopback.set_loopback_hostname("examplehost.example.com")
+      expect(@instance_v6_loopback.parsed_file).to eq(expected_hash)
+    end
+  end
+
   describe "#set_canonical_hostname" do
     it "removes an existing entry and creates a new one" do
       expected_hash = [{:blank => true},


### PR DESCRIPTION
This PR will add a new method to the calling API that can be used to set both the IPv6 and IPv4 loopback hostnames with a single  call.