### PR TITLE
Add a #show method to the service classes

### DIFF
--- a/lib/linux_admin/service/sys_v_init_service.rb
+++ b/lib/linux_admin/service/sys_v_init_service.rb
@@ -51,5 +51,9 @@ module LinuxAdmin
     def status
       Common.run(Common.cmd(:service), :params => [name, "status"]).output
     end
+
+    def show
+      raise NotImplementedError
+    end
   end
 end

--- a/lib/linux_admin/service/systemd_service.rb
+++ b/lib/linux_admin/service/systemd_service.rb
@@ -45,10 +45,28 @@ module LinuxAdmin
       Common.run(command_path, :params => ["status", name]).output
     end
 
+    def show
+      output = Common.run!(command_path, :params => ["show", name]).output
+      output.split("\n").each_with_object({}) do |line, h|
+        k, v = line.split("=", 2)
+        h[k] = cast_show_value(k, v)
+      end
+    end
+
     private
 
     def command_path
       Common.cmd(:systemctl)
+    end
+
+    def cast_show_value(key, value)
+      return value.to_i if value =~ /^\d+$/
+      return parse_exec_value(value) if key =~ /Exec(Start|Stop)/
+      value
+    end
+
+    def parse_exec_value(value)
+      value[1..-2].strip.split(" ; ").map { |s| s.split("=", 2) }.to_h
     end
   end
 end

--- a/lib/linux_admin/service/systemd_service.rb
+++ b/lib/linux_admin/service/systemd_service.rb
@@ -61,8 +61,15 @@ module LinuxAdmin
 
     def cast_show_value(key, value)
       return value.to_i if value =~ /^\d+$/
-      return parse_exec_value(value) if key =~ /Exec(Start|Stop)/
-      value
+
+      case key
+      when /^.*Timestamp$/
+        Time.parse(value)
+      when /Exec(Start|Stop)/
+        parse_exec_value(value)
+      else
+        value
+      end
     end
 
     def parse_exec_value(value)

--- a/spec/service/systemd_service_spec.rb
+++ b/spec/service/systemd_service_spec.rb
@@ -110,6 +110,7 @@ describe LinuxAdmin::SystemdService do
     it "returns a hash of runtime information" do
       output = <<-EOS
 MainPID=29189
+ExecMainStartTimestamp=Wed 2017-02-08 13:49:57 EST
 ExecStart={ path=/bin/sh ; argv[]=/bin/sh -c /bin/evmserver.sh start ; status=0/0 }
 ExecStop={ path=/bin/sh ; argv[]=/bin/sh -c /bin/evmserver.sh stop ; status=0/0 }
 ControlGroup=/system.slice/evmserverd.service
@@ -117,11 +118,12 @@ MemoryCurrent=2865373184
 EOS
 
       hash = {
-        "MainPID"       => 29_189,
-        "ExecStart"     => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh start", "status" => "0/0"},
-        "ExecStop"      => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh stop", "status" => "0/0"},
-        "ControlGroup"  => "/system.slice/evmserverd.service",
-        "MemoryCurrent" => 2_865_373_184
+        "MainPID"                => 29_189,
+        "ExecMainStartTimestamp" => Time.new(2017, 2, 8, 13, 49, 57, "-05:00"),
+        "ExecStart"              => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh start", "status" => "0/0"},
+        "ExecStop"               => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh stop", "status" => "0/0"},
+        "ControlGroup"           => "/system.slice/evmserverd.service",
+        "MemoryCurrent"          => 2_865_373_184
       }
       expect(LinuxAdmin::Common).to receive(:run!)
         .with(command, :params => %w(show foo)).and_return(double(:output => output))

--- a/spec/service/systemd_service_spec.rb
+++ b/spec/service/systemd_service_spec.rb
@@ -105,4 +105,27 @@ describe LinuxAdmin::SystemdService do
       expect(@service.status).to eq(status)
     end
   end
+
+  describe "#show" do
+    it "returns a hash of runtime information" do
+      output = <<-EOS
+MainPID=29189
+ExecStart={ path=/bin/sh ; argv[]=/bin/sh -c /bin/evmserver.sh start ; status=0/0 }
+ExecStop={ path=/bin/sh ; argv[]=/bin/sh -c /bin/evmserver.sh stop ; status=0/0 }
+ControlGroup=/system.slice/evmserverd.service
+MemoryCurrent=2865373184
+EOS
+
+      hash = {
+        "MainPID"       => 29_189,
+        "ExecStart"     => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh start", "status" => "0/0"},
+        "ExecStop"      => {"path" => "/bin/sh", "argv[]" => "/bin/sh -c /bin/evmserver.sh stop", "status" => "0/0"},
+        "ControlGroup"  => "/system.slice/evmserverd.service",
+        "MemoryCurrent" => 2_865_373_184
+      }
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(command, :params => %w(show foo)).and_return(double(:output => output))
+      expect(@service.show).to eq(hash)
+    end
+  end
 end


### PR DESCRIPTION
For systemd `show` prints some useful metrics about the unit and the cgroup at runtime.

This can be used to get memory used, memory/cpu limits and the main PID of the unit.
https://www.freedesktop.org/software/systemd/man/systemctl.html#show%20PATTERN...%7CJOB...

There is no equivalent call for SysV scripts so we raise `NotImplementedError` for the show method there.
https://fedoraproject.org/wiki/SysVinit_to_Systemd_Cheatsheet

@jrafanie we would have to then look at the `MemoryCurrent` key in the returned hash. I was debating creating a separate method for `memory`, but wasn't sure about how far I wanted to diverge the API of `SysVInitService` and `SystemdService`

@bdunne please review