### PR TITLE
Introduce methods for setting up static ipv6

### DIFF
--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -60,6 +60,15 @@ module LinuxAdmin
       @interface_config["GATEWAY"] = address
     end
 
+    # Set the IPv6 gateway address for this interface
+    #
+    # @param address [String] IPv6 address optionally including the prefix length
+    # @raise ArgumentError if the address is not formatted properly
+    def gateway6=(address)
+      validate_ip(address)
+      @interface_config['IPV6_DEFAULTGW'] = address
+    end
+
     # Set the IPv4 sub-net mask for this interface
     #
     # @param mask [String]

--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -125,6 +125,23 @@ module LinuxAdmin
       save
     end
 
+    # Applies the given static IPv6 network configuration to the interface
+    #
+    # @param ip [String] IPv6 address
+    # @param prefix [Number] prefix length for IPv6 address
+    # @param gw [String] gateway address
+    # @param dns [Array<String>] list of dns servers
+    # @param search [Array<String>] list of search domains
+    # @return [Boolean] true on success, false otherwise
+    # @raise ArgumentError if an IP is not formatted properly or interface does not start
+    def apply_static6(ip, prefix, gw, dns, search = nil)
+      self.address6     = "#{ip}/#{prefix}"
+      self.gateway6     = gw
+      self.dns          = dns
+      self.search_order = search if search
+      save
+    end
+
     # Writes the contents of @interface_config to @interface_file as `key`=`value` pairs
     # and resets the interface
     #

--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -39,6 +39,18 @@ module LinuxAdmin
       @interface_config["IPADDR"]    = address
     end
 
+    # Set the IPv6 address for this interface
+    #
+    # @param address [String] IPv6 address including the prefix length (i.e. '::1/127')
+    # @raise ArgumentError if the address is not formatted properly
+    def address6=(address)
+      validate_ip(address)
+      @interface_config['BOOTPROTO'] = 'static'
+      @interface_config['IPV6INIT']  = 'yes'
+      @interface_config['DHCPV6C']   = 'no'
+      @interface_config['IPV6ADDR']  = address
+    end
+
     # Set the IPv4 gateway address for this interface
     #
     # @param address [String]

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -128,6 +128,14 @@ EOF
     end
   end
 
+  describe '#gateway6=' do
+    it 'sets the default gateway for IPv6' do
+      address = 'fe80::1/64'
+      dhcp_interface.gateway6 = address
+      expect(dhcp_interface.interface_config['IPV6_DEFAULTGW']).to eq(address)
+    end
+  end
+
   describe "#netmask=" do
     it "sets the sub-net mask" do
       mask = "255.255.255.0"

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -100,6 +100,22 @@ EOF
     end
   end
 
+  describe '#address6=' do
+    it 'sets the ipv6 address' do
+      address = 'fe80::1/64'
+      dhcp_interface.address6 = address
+      conf = dhcp_interface.interface_config
+      expect(conf['IPV6ADDR']).to eq(address)
+      expect(conf['BOOTPROTO']).to eq('static')
+      expect(conf['IPV6INIT']).to eq('yes')
+      expect(conf['DHCPV6C']).to eq('no')
+    end
+
+    it 'raises error when given a bad address' do
+      expect { dhcp_interface.address6 = '1::1::1' }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#gateway=" do
     it "sets the gateway address" do
       address = "192.168.1.1"

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -225,6 +225,16 @@ EOF
     end
   end
 
+  describe '#apply_static6' do
+    it 'sets the static IPv6 configuration' do
+      expect(dhcp_interface).to receive(:save)
+      dhcp_interface.apply_static6('d:e:a:d:b:e:e:f', 127, 'd:e:a:d::/64', ['d:e:a:d::'])
+      conf = dhcp_interface.interface_config
+      expect(conf).to include('BOOTPROTO' => 'static', 'IPV6INIT' => 'yes', 'DHCPV6C' => 'no',
+                              'IPV6ADDR' => 'd:e:a:d:b:e:e:f/127', 'IPV6_DEFAULTGW' => 'd:e:a:d::/64')
+    end
+  end
+
   describe "#save" do
     let(:iface_file) { Pathname.new("/etc/sysconfig/network-scripts/ifcfg-#{device_name}") }
 


### PR DESCRIPTION
# What
 - Introduce `address6=` method for setting static IPv6 address in /etc/sysconfig/network-scripts/ifcfg
 - introduce `gateway6=` method
 - introduce `apply_static6` method