### PR TITLE
Support systems without network

### DIFF
--- a/lib/linux_admin/network_interface.rb
+++ b/lib/linux_admin/network_interface.rb
@@ -90,7 +90,7 @@ module LinuxAdmin
     #
     # @return [String] IPv4 netmask
     def netmask
-      @network_conf[:mask] ||= IPAddr.new('255.255.255.255').mask(prefix).to_s
+      @network_conf[:mask] ||= IPAddr.new('255.255.255.255').mask(prefix).to_s if prefix
     end
 
     # Retrieve the IPv6 sub-net mask assigned to the interface
@@ -99,7 +99,7 @@ module LinuxAdmin
     # @raise [ArgumentError] if the given scope is not `:global` or `:link`
     def netmask6(scope = :global)
       if [:global, :link].include?(scope)
-        @network_conf["mask6_#{scope}".to_sym] ||= IPAddr.new('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff').mask(prefix6(scope)).to_s
+        @network_conf["mask6_#{scope}".to_sym] ||= IPAddr.new('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff').mask(prefix6(scope)).to_s if prefix6(scope)
       else
         raise ArgumentError, "Unrecognized address scope #{scope}"
       end


### PR DESCRIPTION
Bring support for systems with no IP back.

Fixes errors like:
```
      NoMethodError: undefined method `<' for nil:NilClass
	from .rbenv/versions/2.3.3/lib/ruby/2.3.0/ipaddr.rb:430:in `mask!'
	from .rbenv/versions/2.3.3/lib/ruby/2.3.0/ipaddr.rb:158:in `mask'
	from ManageIQ/linux_admin/lib/linux_admin/network_interface.rb:94:in `netmask'
```
That was introduced in 6a19600a573cbbb903f093419309bc0a0a2ed2b1

@miq-bot add_label bug