### PR TITLE
LinuxAdmin.run/run! used to work, put it back via delegation

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -38,10 +38,13 @@ require 'forwardable'
 module LinuxAdmin
   class << self
     extend Forwardable
+    extend Gem::Deprecate
     attr_writer :logger
 
     def_delegators Common, :run
     def_delegators Common, :run!
+    deprecate :run,  "AwesomeSpawn.run",  2017, 6
+    deprecate :run!, "AwesomeSpawn.run!", 2017, 6
   end
 
   def self.logger

--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -33,10 +33,15 @@ require 'linux_admin/ip_address'
 require 'linux_admin/dns'
 require 'linux_admin/network_interface'
 require 'linux_admin/chrony'
+require 'forwardable'
 
 module LinuxAdmin
   class << self
+    extend Forwardable
     attr_writer :logger
+
+    def_delegators Common, :run
+    def_delegators Common, :run!
   end
 
   def self.logger

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -19,17 +19,19 @@ describe LinuxAdmin::Common do
     end
   end
 
-  describe "#run" do
-    it "runs a command with AwesomeSpawn.run" do
-      expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
-      described_class.run("echo", nil => "test")
+  [described_class, LinuxAdmin].each do |klass|
+    describe "#{klass}.run" do
+      it "runs a command with AwesomeSpawn.run" do
+        expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
+        klass.run("echo", nil => "test")
+      end
     end
-  end
 
-  describe "#run!" do
-    it "runs a command with AwesomeSpawn.run!" do
-      expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
-      described_class.run!("echo", nil => "test")
+    describe "#{klass}.run!" do
+      it "runs a command with AwesomeSpawn.run!" do
+        expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
+        klass.run!("echo", nil => "test")
+      end
     end
   end
 end


### PR DESCRIPTION
This regressed here:
https://github.com/ManageIQ/linux_admin/commit/9e7d11322d793fe572a0cb94ffcded36bb4bfb94

Existing scripts that worked on 0.14.0 would be broken by 0.15.0+