### PR TITLE
Fix configure network fails after a successful DHCP configuration

### DIFF
--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -161,7 +161,9 @@ module LinuxAdmin
     def save
       old_contents = File.read(@interface_file)
 
-      return false unless stop
+      stop_success = stop
+      stop_success = stop unless stop_success
+      return false unless stop_success
 
       File.write(@interface_file, @interface_config.delete_blanks.collect { |k, v| "#{k}=#{v}" }.join("\n"))
 

--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -162,6 +162,11 @@ module LinuxAdmin
       old_contents = File.read(@interface_file)
 
       stop_success = stop
+      # Stop twice because when configure both ipv4 and ipv6 as dhcp, ipv6 dhcp client will
+      # exit and leave a /var/run/dhclient6-eth0.pid file. Then stop (ifdown eth0) will try
+      # to kill this exited process so it returns 1. In the second call, this `.pid' file
+      # has been deleted and ifdown returns 0.
+      # See: https://bugzilla.redhat.com/show_bug.cgi?id=1472396
       stop_success = stop unless stop_success
       return false unless stop_success
 

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -269,7 +269,7 @@ EOF
 
     it "returns false when the interface cannot be brought down" do
       expect(File).to receive(:read).with(iface_file)
-      expect(dhcp_interface).to receive(:stop).and_return(false)
+      expect(dhcp_interface).to receive(:stop).twice.and_return(false)
       expect(File).not_to receive(:write)
       expect(dhcp_interface.save).to be false
     end


### PR DESCRIPTION
**ISSUE**: After a successful DHCP configuration, if you configure network using static ipv6 it will fails. That fails is actually `ifdown` returns `1` indicate previous setting to network (DHCP) one is not successfully shutdown. However, actually it does if you run `ifconfig` at this time. This is why the network configuration becomes empty in appliance console status: `ifdown` fails so `NetworkInterfaceRH.save` returns `false` immediately without start up `eth0` using old configuration or new configuration. After `ifdown` returns `1` if we run another `ifdown` it will return `0` and subsequent `ifup` new configuration works.

**BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1464999

\cc @yrudman @carbonin 

@miq-bot add-label wip,bug