### PR TITLE
Don't change BOOTPROTO to static when setting a static IPv6 address

### DIFF
--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -45,7 +45,6 @@ module LinuxAdmin
     # @raise ArgumentError if the address is not formatted properly
     def address6=(address)
       validate_ip(address)
-      @interface_config['BOOTPROTO'] = 'static'
       @interface_config['IPV6INIT']  = 'yes'
       @interface_config['DHCPV6C']   = 'no'
       @interface_config['IPV6ADDR']  = address

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -106,7 +106,6 @@ EOF
       dhcp_interface.address6 = address
       conf = dhcp_interface.interface_config
       expect(conf['IPV6ADDR']).to eq(address)
-      expect(conf['BOOTPROTO']).to eq('static')
       expect(conf['IPV6INIT']).to eq('yes')
       expect(conf['DHCPV6C']).to eq('no')
     end
@@ -241,8 +240,7 @@ EOF
       expect(dhcp_interface).to receive(:save)
       dhcp_interface.apply_static6('d:e:a:d:b:e:e:f', 127, 'd:e:a:d::/64', ['d:e:a:d::'])
       conf = dhcp_interface.interface_config
-      expect(conf).to include('BOOTPROTO' => 'static', 'IPV6INIT' => 'yes', 'DHCPV6C' => 'no',
-                              'IPV6ADDR' => 'd:e:a:d:b:e:e:f/127', 'IPV6_DEFAULTGW' => 'd:e:a:d::/64')
+      expect(conf).to include('IPV6INIT' => 'yes', 'DHCPV6C' => 'no', 'IPV6ADDR' => 'd:e:a:d:b:e:e:f/127', 'IPV6_DEFAULTGW' => 'd:e:a:d::/64')
     end
   end
 


### PR DESCRIPTION
This tells the network service to not start dhclient at all which will result in us not getting a v4 address if we were previously relying on dhcp for that.

https://bugzilla.redhat.com/show_bug.cgi?id=1464994

Notice no mention of `BOOTPROTO` in https://access.redhat.com/solutions/347693

/cc @ailisp @yrudman 