### PR TITLE
Allow using NetworkInterface when the file doesn't exist yet

### DIFF
--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -180,7 +180,7 @@ module LinuxAdmin
         return false
       end
 
-      true
+      reload
     end
 
     def self.path_to_interface_config_file(interface)

--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -10,8 +10,7 @@ module LinuxAdmin
 
     # @param interface [String] Name of the network interface to manage
     def initialize(interface)
-      @interface_file = Pathname.new(IFACE_DIR).join("ifcfg-#{interface}")
-      raise MissingConfigurationFileError unless File.exist?(@interface_file)
+      @interface_file = self.class.path_to_interface_config_file(interface)
       super
       parse_conf
     end
@@ -20,12 +19,15 @@ module LinuxAdmin
     def parse_conf
       @interface_config = {}
 
-      File.foreach(@interface_file) do |line|
-        next if line =~ /^\s*#/
+      if @interface_file.file?
+        File.foreach(@interface_file) do |line|
+          next if line =~ /^\s*#/
 
-        key, value = line.split('=').collect(&:strip)
-        @interface_config[key] = value
+          key, value = line.split('=').collect(&:strip)
+          @interface_config[key] = value
+        end
       end
+
       @interface_config["NM_CONTROLLED"] = "no"
     end
 
@@ -159,7 +161,7 @@ module LinuxAdmin
     # @return [Boolean] true if the interface was successfully brought up with the
     #   new configuration, false otherwise
     def save
-      old_contents = File.read(@interface_file)
+      old_contents = @interface_file.file? ? File.read(@interface_file) : ""
 
       stop_success = stop
       # Stop twice because when configure both ipv4 and ipv6 as dhcp, ipv6 dhcp client will
@@ -179,6 +181,10 @@ module LinuxAdmin
       end
 
       true
+    end
+
+    def self.path_to_interface_config_file(interface)
+      Pathname.new(IFACE_DIR).join("ifcfg-#{interface}")
     end
 
     private

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -39,6 +39,9 @@ EOF
 
   subject(:dhcp_interface) do
     allow(File).to receive(:exist?).and_return(true)
+    stub_path = described_class.path_to_interface_config_file(device_name)
+    allow(Pathname).to receive(:new).and_return(stub_path)
+    allow(stub_path).to receive(:file?).and_return(true)
     stub_foreach_to_string(ifcfg_file_dhcp)
     allow(AwesomeSpawn).to receive(:run!).exactly(4).times.and_return(result("", 0))
     described_class.new(device_name)

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -43,7 +43,7 @@ EOF
     allow(Pathname).to receive(:new).and_return(stub_path)
     allow(stub_path).to receive(:file?).and_return(true)
     stub_foreach_to_string(ifcfg_file_dhcp)
-    allow(AwesomeSpawn).to receive(:run!).exactly(4).times.and_return(result("", 0))
+    allow(AwesomeSpawn).to receive(:run!).exactly(6).times.and_return(result("", 0))
     described_class.new(device_name)
   end
 


### PR DESCRIPTION
Also rescue failures for refreshing interfaces that don't exist
https://bugzilla.redhat.com/show_bug.cgi?id=1439345