### PR TITLE
Add platform attribute to Scap class

### DIFF
--- a/spec/scap_spec.rb
+++ b/spec/scap_spec.rb
@@ -1,4 +1,7 @@
 describe LinuxAdmin::Scap do
+  subject(:rhel7) { described_class.new("rhel7") }
+  subject(:rhel6) { described_class.new("rhel6") }
+
   describe "#lockdown" do
     it "raises if given no rules" do
       stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new(data_file_path("scap")))
@@ -7,6 +10,22 @@ describe LinuxAdmin::Scap do
       allow(described_class).to receive(:ssg_available?).and_return(true)
       allow(scap).to receive(:lockdown_profile)
       expect { scap.lockdown("value1" => true) }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#xccdf_file (private)" do
+    it "uses the platform from the attribute" do
+      stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new(data_file_path("scap")))
+      expect(rhel7.send(:xccdf_file)).to eq("#{data_file_path("scap")}/ssg-rhel7-xccdf.xml")
+      expect(rhel6.send(:xccdf_file)).to eq("#{data_file_path("scap")}/ssg-rhel6-xccdf.xml")
+    end
+  end
+
+  describe "#oval_file (private)" do
+    it "uses the platform from the attribute" do
+      stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new(data_file_path("scap")))
+      expect(rhel7.send(:oval_file)).to eq("#{data_file_path("scap")}/ssg-rhel7-oval.xml")
+      expect(rhel6.send(:oval_file)).to eq("#{data_file_path("scap")}/ssg-rhel6-oval.xml")
     end
   end
 
@@ -42,19 +61,19 @@ describe LinuxAdmin::Scap do
   describe ".local_ssg_file (private)" do
     it "returns nil if the file doesn't exist" do
       stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new("/doesnt/exist/"))
-      file = described_class.send(:local_ssg_file, "type")
+      file = described_class.send(:local_ssg_file, "type", nil)
       expect(file).to be_nil
     end
 
     it "returns a file if there are multiple matches" do
       stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new(data_file_path("scap")))
-      file = described_class.send(:local_ssg_file, "xccdf")
+      file = described_class.send(:local_ssg_file, "xccdf", nil)
       expect(file).to match(%r{.*/ssg-\w+-xccdf\.xml})
     end
 
     it "returns a matching file" do
       stub_const("LinuxAdmin::Scap::SSG_XML_PATH", Pathname.new(data_file_path("scap")))
-      file = described_class.send(:local_ssg_file, "oval")
+      file = described_class.send(:local_ssg_file, "oval", nil)
       expect(file).to eq("#{data_file_path("scap")}/ssg-rhel7-oval.xml")
     end
   end


### PR DESCRIPTION
Newer versions of scap-security-guide (> 0.1.32) add new xccdf files which match our glob pattern, but do not contain the remediations for the rules we want to run.

If we edit one of these files rather than the one for our target platform, the rules will not be remediated properly.

Specifying the platform allows us to find the file we need.

https://bugzilla.redhat.com/show_bug.cgi?id=1493193