### PR TITLE
Move disk private methods to one section

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -8,47 +8,6 @@ module LinuxAdmin
 
     attr_accessor :path
 
-    private
-
-    def str_to_bytes(val, unit)
-      case unit
-      when 'K' then
-        val.to_f * 1_024 # 1.kilobytes
-      when 'M' then
-        val.to_f * 1_048_576 # 1.megabyte
-      when 'G' then
-        val.to_f * 1_073_741_824 # 1.gigabytes
-      end
-    end
-
-    def overlapping_ranges?(ranges)
-      ranges.find do |range1|
-        ranges.any? do |range2|
-          range1 != range2 &&
-            ranges_overlap?(range1, range2)
-        end
-      end
-    end
-
-    def ranges_overlap?(range1, range2) # copied from activesupport Range#overlaps?
-      range1.cover?(range2.first) || range2.cover?(range1.first)
-    end
-
-    def check_if_partitions_overlap(partitions)
-      ranges =
-        partitions.collect do |partition|
-          start  = partition[:start]
-          finish = partition[:end]
-          start.delete('%')
-          finish.delete('%')
-          start.to_f..finish.to_f
-        end
-
-      if overlapping_ranges?(ranges)
-        raise ArgumentError, "overlapping partitions"
-      end
-    end
-
     public
 
     def self.local
@@ -184,6 +143,45 @@ module LinuxAdmin
     end
 
     private
+
+    def str_to_bytes(val, unit)
+      case unit
+      when 'K' then
+        val.to_f * 1_024 # 1.kilobytes
+      when 'M' then
+        val.to_f * 1_048_576 # 1.megabyte
+      when 'G' then
+        val.to_f * 1_073_741_824 # 1.gigabytes
+      end
+    end
+
+    def overlapping_ranges?(ranges)
+      ranges.find do |range1|
+        ranges.any? do |range2|
+          range1 != range2 &&
+            ranges_overlap?(range1, range2)
+        end
+      end
+    end
+
+    def ranges_overlap?(range1, range2) # copied from activesupport Range#overlaps?
+      range1.cover?(range2.first) || range2.cover?(range1.first)
+    end
+
+    def check_if_partitions_overlap(partitions)
+      ranges =
+        partitions.collect do |partition|
+          start  = partition[:start]
+          finish = partition[:end]
+          start.delete('%')
+          finish.delete('%')
+          start.to_f..finish.to_f
+        end
+
+      if overlapping_ranges?(ranges)
+        raise ArgumentError, "overlapping partitions"
+      end
+    end
 
     def parted_options_array(*args)
       args = args.first if args.first.kind_of?(Array)

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -8,8 +8,6 @@ module LinuxAdmin
 
     attr_accessor :path
 
-    public
-
     def self.local
       Dir.glob(['/dev/[vhs]d[a-z]', '/dev/xvd[a-z]']).collect do |d|
         Disk.new :path => d
@@ -40,8 +38,6 @@ module LinuxAdmin
           partition_from_parted(disk)
         }
     end
-
-    public
 
     def create_partition_table(type = "msdos")
       Common.run!(Common.cmd(:parted), :params => {nil => parted_options_array("mklabel", type)})


### PR DESCRIPTION
This file is much more readable with the public methods being implicitly public by sitting at the top of the file and using only one private method section.