### PR TITLE
Bumps net-ssh version from 3.2 to 4.2

### DIFF
--- a/lib/linux_admin/ssh.rb
+++ b/lib/linux_admin/ssh.rb
@@ -25,7 +25,7 @@ module LinuxAdmin
 
     def execute_commands(commands, agent_socket, stdin)
       result = nil
-      args = {:paranoid => false, :number_of_password_prompts => 0}
+      args = {:verify_host_key => false, :number_of_password_prompts => 0}
       if agent_socket
         args.merge!(:forward_agent              => true,
                     :agent_socket_factory       => -> { UNIXSocket.open(agent_socket) })

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -40,5 +40,5 @@ registration, updates, etc.
   spec.add_dependency "more_core_extensions", "~> 3.0"
   spec.add_dependency "nokogiri",             ">= 1.8.1", "~> 1.8"
   spec.add_dependency "openscap"
-  spec.add_dependency "net-ssh", "~> 3.2.0"
+  spec.add_dependency "net-ssh", "~> 4.2.0"
 end

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -33,7 +33,7 @@ sV1Tr/acrE0aWBkD9RYrR2/UwG1zfXuIJeufdWf8c0SY3X6J7jJN
   end
 
   it "should create a call using agent" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :forward_agent => true, :number_of_password_prompts => 0, :agent_socket_factory => Proc).and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :forward_agent => true, :number_of_password_prompts => 0, :agent_socket_factory => Proc).and_return(true)
     ssh_agent = LinuxAdmin::SSHAgent.new(@example_ssh_key)
     ssh_agent.with_service do |socket|
       ssh = LinuxAdmin::SSH.new("127.0.0.1", "root")
@@ -42,12 +42,12 @@ sV1Tr/acrE0aWBkD9RYrR2/UwG1zfXuIJeufdWf8c0SY3X6J7jJN
   end
 
   it "should preform command using private key" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :number_of_password_prompts => 0, :key_data => [@example_ssh_key]).and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :number_of_password_prompts => 0, :key_data => [@example_ssh_key]).and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", @example_ssh_key).perform_commands(%w("ls", "pwd"))
   end
 
   it "should preform command using password" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :paranoid => false, :number_of_password_prompts => 0, :password => "password").and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :number_of_password_prompts => 0, :password => "password").and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", nil, "password").perform_commands(%w("ls", "pwd"))
   end
 end


### PR DESCRIPTION
This is needed b/c net-ssh version 3.2 has issues with Ruby 2.4.

See https://github.com/net-ssh/net-ssh/issues/535

I discovered this while testing https://github.com/ManageIQ/manageiq-ui-classic/pull/2394 and https://github.com/ManageIQ/manageiq-providers-openstack/pull/118