### PR TITLE
Allow pathname objects in Mountable.mount_point_exists?

### DIFF
--- a/lib/linux_admin/mountable.rb
+++ b/lib/linux_admin/mountable.rb
@@ -6,7 +6,7 @@ module LinuxAdmin
     module ClassMethods
       def mount_point_exists?(mount_point)
         result = Common.run!(Common.cmd(:mount))
-        result.output.split("\n").any? { |line| line.split[2] == mount_point }
+        result.output.split("\n").any? { |line| line.split[2] == mount_point.to_s }
       end
 
       def mount_point_available?(mount_point)

--- a/spec/mountable_spec.rb
+++ b/spec/mountable_spec.rb
@@ -37,16 +37,32 @@ eos
     end
 
     context "disk mounted at specified location" do
-      it "returns true" do
+      before do
         expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out1))
+      end
+
+      it "returns true" do
         expect(TestMountable.mount_point_exists?('/mnt/usb')).to be_truthy
+      end
+
+      it "returns true when using a pathname" do
+        path = Pathname.new("/mnt/usb")
+        expect(TestMountable.mount_point_exists?(path)).to be_truthy
       end
     end
 
     context "no disk mounted at specified location" do
-      it "returns false" do
+      before do
         expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out2))
+      end
+
+      it "returns false" do
         expect(TestMountable.mount_point_exists?('/mnt/usb')).to be_falsey
+      end
+
+      it "returns false when using a pathname" do
+        path = Pathname.new("/mnt/usb")
+        expect(TestMountable.mount_point_exists?(path)).to be_falsey
       end
     end
   end
@@ -59,16 +75,32 @@ eos
     end
 
     context "disk mounted at specified location" do
-      it "returns false" do
+      before do
         expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out1))
+      end
+
+      it "returns false" do
         expect(TestMountable.mount_point_available?('/mnt/usb')).to be_falsey
+      end
+
+      it "returns false when using a pathname" do
+        path = Pathname.new("/mnt/usb")
+        expect(TestMountable.mount_point_available?(path)).to be_falsey
       end
     end
 
     context "no disk mounted at specified location" do
-      it "returns true" do
+      before do
         expect(LinuxAdmin::Common).to receive(:run!).and_return(double(:output => @mount_out2))
+      end
+
+      it "returns true" do
         expect(TestMountable.mount_point_available?('/mnt/usb')).to be_truthy
+      end
+
+      it "returns true when using a pathname" do
+        path = Pathname.new("/mnt/usb")
+        expect(TestMountable.mount_point_available?(path)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Addressing concerns from https://github.com/ManageIQ/manageiq-gems-pending/pull/286#issuecomment-337015479