### PR TITLE
"subscription-manager identity" needs proxy info if you're using one

### DIFF
--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -17,7 +17,7 @@ module LinuxAdmin
       end
     end
 
-    def registered?
+    def registered?(_options = nil)
       false
     end
 

--- a/lib/linux_admin/registration_system/rhn.rb
+++ b/lib/linux_admin/registration_system/rhn.rb
@@ -5,7 +5,7 @@ module LinuxAdmin
     SATELLITE5_SERVER_CERT_PATH = "pub/rhn-org-trusted-ssl-cert-1.0-1.noarch.rpm"
     INSTALLED_SERVER_CERT_PATH  = "/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT"
 
-    def registered?
+    def registered?(_options = nil)
       id = ""
       if File.exist?(systemid_file)
         xml = Nokogiri.XML(File.read(systemid_file))

--- a/lib/linux_admin/registration_system/subscription_manager.rb
+++ b/lib/linux_admin/registration_system/subscription_manager.rb
@@ -15,8 +15,10 @@ module LinuxAdmin
       !!organizations(options)
     end
 
-    def registered?
-      Common.run("subscription-manager identity").exit_status == 0
+    def registered?(options = nil)
+      args = ["subscription-manager identity"]
+      args << {:params => proxy_params(options)} if options
+      Common.run(*args).exit_status == 0
     end
 
     def refresh

--- a/lib/linux_admin/registration_system/subscription_manager.rb
+++ b/lib/linux_admin/registration_system/subscription_manager.rb
@@ -18,7 +18,7 @@ module LinuxAdmin
     def registered?(options = nil)
       args = ["subscription-manager identity"]
       args << {:params => proxy_params(options)} if options
-      Common.run(*args).exit_status == 0
+      Common.run(*args).exit_status.zero?
     end
 
     def refresh

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -28,9 +28,36 @@ describe LinuxAdmin::RegistrationSystem do
     end
   end
 
-  it "#registered? when unregistered" do
-    stub_registered_to_system(nil)
-    expect(described_class.registered?).to be_falsey
+  context "#registered?" do
+    it "when unregistered" do
+      stub_registered_to_system(nil)
+      expect(described_class.registered?).to be_falsey
+    end
+
+    context "SubscriptionManager" do
+      it "with no args" do
+        expect(LinuxAdmin::Common).to receive(:run).with("subscription-manager identity").and_return(double(:exit_status => 0))
+
+        LinuxAdmin::SubscriptionManager.new.registered?
+      end
+
+      it "with a proxy" do
+        expect(LinuxAdmin::Common).to receive(:run).with(
+          "subscription-manager identity",
+          :params => {
+            "--proxy="         => "https://example.com",
+            "--proxyuser="     => "user",
+            "--proxypassword=" => "pass"
+          }
+        ).and_return(double(:exit_status => 0))
+
+        LinuxAdmin::SubscriptionManager.new.registered?(
+          :proxy_address  => "https://example.com",
+          :proxy_username => "user",
+          :proxy_password => "pass"
+        )
+      end
+    end
   end
 
   context ".method_missing" do


### PR DESCRIPTION
For https://github.com/ManageIQ/manageiq/pull/16610

https://bugzilla.redhat.com/show_bug.cgi?id=1518695