### PR TITLE
Deprecate LinuxAdmin::Rhn

### DIFF
--- a/lib/linux_admin/registration_system/rhn.rb
+++ b/lib/linux_admin/registration_system/rhn.rb
@@ -5,6 +5,10 @@ module LinuxAdmin
     SATELLITE5_SERVER_CERT_PATH = "pub/rhn-org-trusted-ssl-cert-1.0-1.noarch.rpm"
     INSTALLED_SERVER_CERT_PATH  = "/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT"
 
+    def initialize
+      warn("[DEPRECATION] 'LinuxAdmin::Rhn' is deprecated.  Please use 'LinuxAdmin::SubscriptionManager' instead.")
+    end
+
     def registered?(_options = nil)
       id = ""
       if File.exist?(systemid_file)


### PR DESCRIPTION
RHN is no longer active, we no longer need this class.

Example (the raise is because I don't have `subscription-manager` installed):
```ruby
$ irb -Ilib
irb(main):001:0> require 'linux_admin'
=> true
irb(main):002:0> LinuxAdmin::RegistrationSystem.registered?
[DEPRECATION] 'LinuxAdmin::Rhn' is deprecated.  Please use 'LinuxAdmin::SubscriptionManager' instead.
AwesomeSpawn::NoSuchFileError: No such file or directory - subscription-manager
	from /home/bdunne/.gem/ruby/2.3.3/gems/awesome_spawn-1.4.1/lib/awesome_spawn.rb:81:in `rescue in run'
	from /home/bdunne/.gem/ruby/2.3.3/gems/awesome_spawn-1.4.1/lib/awesome_spawn.rb:71:in `run'
	from /home/bdunne/projects/rubygems/linux_admin/lib/linux_admin/common.rb:19:in `run'
	from /home/bdunne/projects/rubygems/linux_admin/lib/linux_admin/registration_system/subscription_manager.rb:21:in `registered?'
	from /home/bdunne/projects/rubygems/linux_admin/lib/linux_admin/registration_system.rb:29:in `registration_type_uncached'
	from /home/bdunne/projects/rubygems/linux_admin/lib/linux_admin/registration_system.rb:7:in `registration_type'
	from /home/bdunne/projects/rubygems/linux_admin/lib/linux_admin/registration_system.rb:12:in `method_missing'
	from (irb):2
	from /home/bdunne/.rubies/ruby-2.3.3/bin/irb:11:in `<main>'
irb(main):003:0> LinuxAdmin::Rhn.new
[DEPRECATION] 'LinuxAdmin::Rhn' is deprecated.  Please use 'LinuxAdmin::SubscriptionManager' instead.
=> #<LinuxAdmin::Rhn:0x00000002412fb0>
```