### PR TITLE
Prioritize SubscriptionManager over Rhn, and other warning fixes

### DIFF
--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -24,7 +24,9 @@ module LinuxAdmin
     private
 
     def self.registration_type_uncached
-      if SubscriptionManager.new.registered?
+      if new.registered?
+        self
+      elsif SubscriptionManager.new.registered?
         SubscriptionManager
       elsif Rhn.new.registered?
         Rhn

--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -24,10 +24,10 @@ module LinuxAdmin
     private
 
     def self.registration_type_uncached
-      if Rhn.new.registered?
-        Rhn
-      elsif SubscriptionManager.new.registered?
+      if SubscriptionManager.new.registered?
         SubscriptionManager
+      elsif Rhn.new.registered?
+        Rhn
       else
         self
       end

--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -3,6 +3,7 @@ module LinuxAdmin
     include Logging
 
     def self.registration_type(reload = false)
+      @registration_type ||= nil # prevent ruby warning
       return @registration_type if @registration_type && !reload
       @registration_type = registration_type_uncached
     end

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -1,4 +1,11 @@
-describe LinuxAdmin::RegistrationSystem do
+shared_context "RegistrationSystem.registration_type stubbing", :registered_system_stubbing do
+  def stub_registered_to_system(*system)
+    allow_any_instance_of(LinuxAdmin::SubscriptionManager).to receive_messages(:registered? => system.include?(:sm))
+    allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => system.include?(:rhn))
+  end
+end
+
+describe LinuxAdmin::RegistrationSystem, :registered_system_stubbing do
   context ".registration_type" do
     it "when registered Subscription Manager" do
       stub_registered_to_system(:sm)
@@ -82,9 +89,22 @@ describe LinuxAdmin::RegistrationSystem do
       expect { LinuxAdmin::RegistrationSystem.method_does_not_exist }.to raise_error(NoMethodError)
     end
   end
+end
 
-  def stub_registered_to_system(*system)
-    allow_any_instance_of(LinuxAdmin::SubscriptionManager).to receive_messages(:registered? => (system.include?(:sm)))
-    allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => (system.include?(:rhn)))
+describe LinuxAdmin::SubscriptionManager, :registered_system_stubbing do
+  context ".registration_type" do
+    it "when registered both" do
+      stub_registered_to_system(:sm, :rhn)
+      expect(described_class.registration_type).to eq(LinuxAdmin::SubscriptionManager)
+    end
+  end
+end
+
+describe LinuxAdmin::Rhn, :registered_system_stubbing do
+  context ".registration_type" do
+    it "when registered both" do
+      stub_registered_to_system(:sm, :rhn)
+      expect(described_class.registration_type).to eq(LinuxAdmin::Rhn)
+    end
   end
 end

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -5,9 +5,14 @@ describe LinuxAdmin::RegistrationSystem do
       expect(described_class.registration_type).to eq(LinuxAdmin::SubscriptionManager)
     end
 
-    it "when registered RHN" do
-      stub_registered_to_system(:sm, :rhn)
+    it "when registered RHN only" do
+      stub_registered_to_system(:rhn)
       expect(described_class.registration_type).to eq(LinuxAdmin::Rhn)
+    end
+
+    it "when registered both" do
+      stub_registered_to_system(:sm, :rhn)
+      expect(described_class.registration_type).to eq(LinuxAdmin::SubscriptionManager)
     end
 
     it "when unregistered" do

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -1,4 +1,9 @@
 shared_context "RegistrationSystem.registration_type stubbing", :registered_system_stubbing do
+  # stub out `warn` messages from LinuxAdmin::Rhn
+  before do
+    allow_any_instance_of(LinuxAdmin::Rhn).to receive(:warn)
+  end
+
   def stub_registered_to_system(*system)
     allow_any_instance_of(LinuxAdmin::SubscriptionManager).to receive_messages(:registered? => system.include?(:sm))
     allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => system.include?(:rhn))


### PR DESCRIPTION
Now the `LinuxAdmin::Rhn` has been deprecated in https://github.com/ManageIQ/linux_admin/pull/198 , this means that every instantiation of `LinuxAdmin::Rhn` will then add a deprecation warning to `STDOUT`.

Previously, this would also be triggered even if you used the public class methods on `LinuxAdmin::SubscriptionManager` (the deprecation's suggested replacement), because under the hood it determine which to use (`Rhn` or `SubscriptionManager`) by initializing each and calling their `registered?` methods.

Furthermore, these means if `Rhn` is registered on the system in addition to the preferred `SubscriptionManager`, it the `LinuxAdmin::SubscriptionManager.validate_credentials` class method would actually end up calling `LinuxAdmin::Rhn.validate_credentials` instead because of the preference.


The fix
-------

1. It changes the priority to favor `SubscriptionManager` over `Rhn`
2. Adds a new initial check that will check against the subclasss first before trying the other subclasses in the order of our choosing.
3. Fixes some deprecation warnings in specs
    - Removes printing the `"[DEPRECATION] 'LinuxAdmin::Rhn'..."` in the `RegistrationSystem` specs (skipped the other case of it for now)
    - Removes ruby warning for trying to access `@registration_type` without it being defined (can cause warnings in consumers of this gem)


Links
-----

* Related effort: https://github.com/ManageIQ/manageiq/pull/17153