### PR TITLE
Update nokogiri to more secure version

### DIFF
--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -38,7 +38,7 @@ registration, updates, etc.
   spec.add_dependency "awesome_spawn",        "~> 1.3"
   spec.add_dependency "inifile"
   spec.add_dependency "more_core_extensions", "~> 3.0"
-  spec.add_dependency "nokogiri",             ">= 1.8.1", "~> 1.8"
+  spec.add_dependency "nokogiri",             ">= 1.8.2", "~> 1.8"
   spec.add_dependency "openscap"
   spec.add_dependency "net-ssh", "~> 4.2.0"
 end


### PR DESCRIPTION
Hopefully will satisfy hakiri's CVE warnings (seems to).

That said, I could see this as being an issue for `manageiq` or other consumers, so this is more of a "hey, we should probably do this cuz the warning is annoying" PR, and not something that we absolutely have to do "right meow".