### PR TITLE
Use lsblk to detect local disks

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -9,7 +9,8 @@ module LinuxAdmin
     attr_accessor :path
 
     def self.local
-      Dir.glob(['/dev/[vhs]d[a-z]', '/dev/xvd[a-z]']).collect do |d|
+      result = Common.run!(Common.cmd("lsblk"), :params => {:d => nil, :n => nil, :p => nil, :o => "NAME"})
+      result.output.split.collect do |d|
         Disk.new :path => d
       end
     end

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -1,8 +1,10 @@
 describe LinuxAdmin::Disk do
   describe "#local" do
     it "returns local disks" do
-      expect(Dir).to receive(:glob).with(['/dev/[vhs]d[a-z]', '/dev/xvd[a-z]']).
-          and_return(['/dev/hda', '/dev/sda'])
+      expect(LinuxAdmin::Common).to receive(:run!).with(
+        LinuxAdmin::Common.cmd(:lsblk),
+        :params => {:d => nil, :n => nil, :p => nil, :o => "NAME"}
+      ).and_return(double("result", :output => "/dev/hda\n/dev/sda"))
       disks = LinuxAdmin::Disk.local
       paths = disks.collect { |disk| disk.path }
       expect(paths).to include('/dev/hda')


### PR DESCRIPTION
This will remove the need to track all the different disk
naming schemes using a regex.

Specifically it will allow us to find nvme devices which are used
in some AWS instance types

https://bugzilla.redhat.com/show_bug.cgi?id=1629853