### PR TITLE
Support nvme device partitions

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -105,7 +105,7 @@ module LinuxAdmin
 
     def str_to_bytes(val, unit)
       case unit
-      when 'K' then
+      when 'K', 'k' then
         val.to_f * 1_024 # 1.kilobytes
       when 'M' then
         val.to_f * 1_048_576 # 1.megabyte
@@ -164,7 +164,7 @@ module LinuxAdmin
         val = output_disk[i]
         case PARTED_FIELDS[i]
         when :start_sector, :end_sector, :size
-          if val =~ /([0-9\.]*)([KMG])B/
+          if val =~ /([0-9\.]*)([kKMG])B/
             val = str_to_bytes($1, $2)
           end
 

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -6,7 +6,7 @@ module LinuxAdmin
       [:id, :start_sector, :end_sector,
        :size, :partition_type, :fs_type]
 
-    attr_accessor :path
+    attr_accessor :path, :model
 
     def self.local
       result = Common.run!(Common.cmd("lsblk"), :params => {:d => nil, :n => nil, :p => nil, :o => "NAME"})
@@ -16,7 +16,8 @@ module LinuxAdmin
     end
 
     def initialize(args = {})
-      @path = args[:path]
+      @path  = args[:path]
+      @model = "unknown"
     end
 
     def size
@@ -101,6 +102,15 @@ module LinuxAdmin
       self
     end
 
+    def partition_path(id)
+      case model
+      when "nvme"
+        "#{path}p#{id}"
+      else
+        "#{path}#{id}"
+      end
+    end
+
     private
 
     def str_to_bytes(val, unit)
@@ -152,11 +162,17 @@ module LinuxAdmin
       out.each_line do |l|
         if l =~ /^ [0-9].*/
           split << l.split
+        elsif l =~ /^Model:.*/
+          parse_model(l)
         end
       end
       split
     end
 
+    def parse_model(parted_line)
+      matches = parted_line.match(/^Model:.*\((?<model>\w+)\)$/)
+      @model = matches[:model] if matches
+    end
 
     def partition_from_parted(output_disk)
       args = {:disk => self}

--- a/lib/linux_admin/partition.rb
+++ b/lib/linux_admin/partition.rb
@@ -22,7 +22,7 @@ module LinuxAdmin
     end
 
     def path
-      "#{disk.path}#{id}"
+      disk.partition_path(id)
     end
 
     def mount(mount_point=nil)

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -58,43 +58,104 @@ eos
       expect(disk.partitions).to eq([])
     end
 
-    it "sets partitons" do
-      partitions = <<eos
-Model: ATA TOSHIBA MK5061GS (scsi)
-Disk /dev/sda: 500GB
-Sector size (logical/physical): 512B/512B
-Partition Table: msdos
-Disk Flags:
+    context "with nvme parted output" do
+      let(:parted_output) do
+        <<~PARTED
+          Model: NVMe Device (nvme)
+          Disk /dev/nvme0n1: 512GB
+          Sector size (logical/physical): 512B/512B
+          Partition Table: msdos
+          Disk Flags:
 
-Number  Start   End     Size    Type      File system     Flags
- 1      1259kB  81.8GB  80.5GB  primary   ntfs
- 2      81.8GB  162GB   80.5GB  primary   ext4
- 3      162GB   163GB   1074MB  logical   linux-swap(v1)
-eos
-      disk = LinuxAdmin::Disk.new
-      expect(LinuxAdmin::Common).to receive(:run).and_return(double(:output => partitions))
+          Number  Start   End     Size    Type     File system  Flags
+           1      1049kB  1075MB  1074MB  primary  ext4         boot
+           2      1075MB  17.7GB  16.6GB  primary
+           3      17.7GB  512GB   494GB   primary
 
-      expect(disk.partitions[0].id).to eq(1)
-      expect(disk.partitions[0].disk).to eq(disk)
-      expect(disk.partitions[0].size).to eq(86_436_216_832.0)
-      expect(disk.partitions[0].start_sector).to eq(1_289_216.0)
-      expect(disk.partitions[0].end_sector).to eq(87_832_081_203.2)
-      expect(disk.partitions[0].partition_type).to eq('primary')
-      expect(disk.partitions[0].fs_type).to eq('ntfs')
-      expect(disk.partitions[1].id).to eq(2)
-      expect(disk.partitions[1].disk).to eq(disk)
-      expect(disk.partitions[1].size).to eq(86_436_216_832.0)
-      expect(disk.partitions[1].start_sector).to eq(87_832_081_203.2)
-      expect(disk.partitions[1].end_sector).to eq(173_946_175_488)
-      expect(disk.partitions[1].partition_type).to eq('primary')
-      expect(disk.partitions[1].fs_type).to eq('ext4')
-      expect(disk.partitions[2].id).to eq(3)
-      expect(disk.partitions[2].disk).to eq(disk)
-      expect(disk.partitions[2].size).to eq(1_126_170_624)
-      expect(disk.partitions[2].start_sector).to eq(173_946_175_488)
-      expect(disk.partitions[2].end_sector).to eq(175_019_917_312)
-      expect(disk.partitions[2].partition_type).to eq('logical')
-      expect(disk.partitions[2].fs_type).to eq('linux-swap(v1)')
+        PARTED
+      end
+
+      it "sets partitons" do
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:output => parted_output))
+        disk = LinuxAdmin::Disk.new(:path => "/dev/nvme0n1")
+        partitions = disk.partitions
+
+        expect(disk.model).to eq("nvme")
+
+        expect(partitions[0].id).to eq(1)
+        expect(partitions[0].disk).to eq(disk)
+        expect(partitions[0].size).to eq(1_126_170_624.0)
+        expect(partitions[0].start_sector).to eq(1_074_176.0)
+        expect(partitions[0].end_sector).to eq(1_127_219_200.0)
+        expect(partitions[0].partition_type).to eq('primary')
+        expect(partitions[0].fs_type).to eq('ext4')
+        expect(partitions[0].path).to eq('/dev/nvme0n1p1')
+        expect(partitions[1].id).to eq(2)
+        expect(partitions[1].disk).to eq(disk)
+        expect(partitions[1].size).to eq(17_824_114_278.4)
+        expect(partitions[1].start_sector).to eq(1_127_219_200.0)
+        expect(partitions[1].end_sector).to eq(19_005_230_284.8)
+        expect(partitions[1].partition_type).to eq('primary')
+        expect(partitions[1].path).to eq('/dev/nvme0n1p2')
+        expect(partitions[2].id).to eq(3)
+        expect(partitions[2].disk).to eq(disk)
+        expect(partitions[2].size).to eq(530_428_461_056.0)
+        expect(partitions[2].start_sector).to eq(19_005_230_284.8)
+        expect(partitions[2].end_sector).to eq(549_755_813_888.0)
+        expect(partitions[2].partition_type).to eq('primary')
+        expect(partitions[2].path).to eq('/dev/nvme0n1p3')
+      end
+    end
+
+    context "with scsi parted output" do
+      let(:parted_output) do
+        <<~PARTED
+          Model: ATA TOSHIBA MK5061GS (scsi)
+          Disk /dev/sda: 500GB
+          Sector size (logical/physical): 512B/512B
+          Partition Table: msdos
+          Disk Flags:
+
+          Number  Start   End     Size    Type      File system     Flags
+           1      1259kB  81.8GB  80.5GB  primary   ntfs
+           2      81.8GB  162GB   80.5GB  primary   ext4
+           3      162GB   163GB   1074MB  logical   linux-swap(v1)
+
+        PARTED
+      end
+
+      it "sets partitons" do
+        expect(LinuxAdmin::Common).to receive(:run).and_return(double(:output => parted_output))
+        disk = LinuxAdmin::Disk.new(:path => "/dev/sda")
+        partitions = disk.partitions
+
+        expect(disk.model).to eq("scsi")
+
+        expect(partitions[0].id).to eq(1)
+        expect(partitions[0].disk).to eq(disk)
+        expect(partitions[0].size).to eq(86_436_216_832.0)
+        expect(partitions[0].start_sector).to eq(1_289_216.0)
+        expect(partitions[0].end_sector).to eq(87_832_081_203.2)
+        expect(partitions[0].partition_type).to eq('primary')
+        expect(partitions[0].fs_type).to eq('ntfs')
+        expect(partitions[0].path).to eq('/dev/sda1')
+        expect(partitions[1].id).to eq(2)
+        expect(partitions[1].disk).to eq(disk)
+        expect(partitions[1].size).to eq(86_436_216_832.0)
+        expect(partitions[1].start_sector).to eq(87_832_081_203.2)
+        expect(partitions[1].end_sector).to eq(173_946_175_488)
+        expect(partitions[1].partition_type).to eq('primary')
+        expect(partitions[1].fs_type).to eq('ext4')
+        expect(partitions[1].path).to eq('/dev/sda2')
+        expect(partitions[2].id).to eq(3)
+        expect(partitions[2].disk).to eq(disk)
+        expect(partitions[2].size).to eq(1_126_170_624)
+        expect(partitions[2].start_sector).to eq(173_946_175_488)
+        expect(partitions[2].end_sector).to eq(175_019_917_312)
+        expect(partitions[2].partition_type).to eq('logical')
+        expect(partitions[2].fs_type).to eq('linux-swap(v1)')
+        expect(partitions[2].path).to eq('/dev/sda3')
+      end
     end
   end
 

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -67,7 +67,7 @@ Partition Table: msdos
 Disk Flags:
 
 Number  Start   End     Size    Type      File system     Flags
- 1      1259MB  81.8GB  80.5GB  primary   ntfs
+ 1      1259kB  81.8GB  80.5GB  primary   ntfs
  2      81.8GB  162GB   80.5GB  primary   ext4
  3      162GB   163GB   1074MB  logical   linux-swap(v1)
 eos
@@ -76,23 +76,23 @@ eos
 
       expect(disk.partitions[0].id).to eq(1)
       expect(disk.partitions[0].disk).to eq(disk)
-      expect(disk.partitions[0].size).to eq(86_436_216_832.0) # 80.5.gigabytes
-      expect(disk.partitions[0].start_sector).to eq(1_320_157_184) # 1259.megabytes
-      expect(disk.partitions[0].end_sector).to eq(87_832_081_203.2) # 81.8.gigabytes
+      expect(disk.partitions[0].size).to eq(86_436_216_832.0)
+      expect(disk.partitions[0].start_sector).to eq(1_289_216.0)
+      expect(disk.partitions[0].end_sector).to eq(87_832_081_203.2)
       expect(disk.partitions[0].partition_type).to eq('primary')
       expect(disk.partitions[0].fs_type).to eq('ntfs')
       expect(disk.partitions[1].id).to eq(2)
       expect(disk.partitions[1].disk).to eq(disk)
-      expect(disk.partitions[1].size).to eq(86_436_216_832.0) # 80.5.gigabytes
-      expect(disk.partitions[1].start_sector).to eq(87_832_081_203.2) # 81.8.gigabytes
-      expect(disk.partitions[1].end_sector).to eq(173_946_175_488) # 162.gigabytes
+      expect(disk.partitions[1].size).to eq(86_436_216_832.0)
+      expect(disk.partitions[1].start_sector).to eq(87_832_081_203.2)
+      expect(disk.partitions[1].end_sector).to eq(173_946_175_488)
       expect(disk.partitions[1].partition_type).to eq('primary')
       expect(disk.partitions[1].fs_type).to eq('ext4')
       expect(disk.partitions[2].id).to eq(3)
       expect(disk.partitions[2].disk).to eq(disk)
-      expect(disk.partitions[2].size).to eq(1_126_170_624) # 1074.megabytes
-      expect(disk.partitions[2].start_sector).to eq(173_946_175_488) # 162.gigabytes
-      expect(disk.partitions[2].end_sector).to eq(175_019_917_312) # 163.gigabytes
+      expect(disk.partitions[2].size).to eq(1_126_170_624)
+      expect(disk.partitions[2].start_sector).to eq(173_946_175_488)
+      expect(disk.partitions[2].end_sector).to eq(175_019_917_312)
       expect(disk.partitions[2].partition_type).to eq('logical')
       expect(disk.partitions[2].fs_type).to eq('linux-swap(v1)')
     end


### PR DESCRIPTION
Previously we would construct an incorrect path for nvme device partitions because they use a different naming scheme.

For example, the partition with id 1 on the device `/dev/sda` would have path `/dev/sda1` which is what we were implementing previously in `Partition#path`. nvme devices are different in that the first partition of device `/dev/nvme0n1` would not be `/dev/nvme0n11`, but `/dev/nvme0n1p1`.

This patch detects the device model from the parted output and uses the alternate path format if the device is nvme. Otherwise it falls back to the old path scheme whether we can detect a mode or not.

This should (finally) fix https://bugzilla.redhat.com/show_bug.cgi?id=1629853 when it gets released and added to the console.