### PR TITLE
Use strings for ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-- 2.4
-- 2.5
-- 2.6
+- "2.4"
+- "2.5"
+- "2.6"
 - ruby-head
 - jruby-head
 sudo: false


### PR DESCRIPTION
Two number versions such as 2.3 parse as floats so we should
quote the versions for consistency