### PR TITLE
Remove deprecated LinuxAdmin.run!

### DIFF
--- a/lib/linux_admin.rb
+++ b/lib/linux_admin.rb
@@ -33,18 +33,10 @@ require 'linux_admin/ip_address'
 require 'linux_admin/dns'
 require 'linux_admin/network_interface'
 require 'linux_admin/chrony'
-require 'forwardable'
 
 module LinuxAdmin
   class << self
-    extend Forwardable
-    extend Gem::Deprecate
     attr_writer :logger
-
-    def_delegators Common, :run
-    def_delegators Common, :run!
-    deprecate :run,  "AwesomeSpawn.run",  2017, 6
-    deprecate :run!, "AwesomeSpawn.run!", 2017, 6
   end
 
   def self.logger

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -19,19 +19,17 @@ describe LinuxAdmin::Common do
     end
   end
 
-  [described_class, LinuxAdmin].each do |klass|
-    describe "#{klass}.run" do
-      it "runs a command with AwesomeSpawn.run" do
-        expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
-        klass.run("echo", nil => "test")
-      end
+  describe ".run" do
+    it "runs a command with AwesomeSpawn.run" do
+      expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
+      described_class.run("echo", nil => "test")
     end
+  end
 
-    describe "#{klass}.run!" do
-      it "runs a command with AwesomeSpawn.run!" do
-        expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
-        klass.run!("echo", nil => "test")
-      end
+  describe ".run!" do
+    it "runs a command with AwesomeSpawn.run!" do
+      expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
+      described_class.run!("echo", nil => "test")
     end
   end
 end


### PR DESCRIPTION
Remove deprecated `LinuxAdmin.run!` and `run`

Deprecation warning for tests are also removed.