### PR TITLE
[WIP] Add disk size check

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -12,7 +12,7 @@ module LinuxAdmin
       result = Common.run!(Common.cmd("lsblk"), :params => {:d => nil, :n => nil, :p => nil, :o => "NAME"})
       result.output.split.collect do |d|
         Disk.new :path => d
-      end
+      end.select { |disk| disk.size.nonzero? }
     end
 
     def initialize(args = {})


### PR DESCRIPTION
'Choose the database disk: |1| '
    #    1) /dev/sr0: 0 MB
    #    2) /dev/vdb: 4768 MB
    #    3) Don't partition the disk

We shouldn't show /dev/sr0 in that list cause database creation on a SCSI CDROM is not a thing.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1693189

Er, yeah, it needs tests. But I wanted someone to shoot it down first I guess.

(Also I think we have bug in the size method this thing uses so this PR is fixing a symptom.)

@miq-bot add_label bug
@miq-bot assign @jrafanie 
