### PR TITLE
Add respond_to_missing to correspond with method_missing

### DIFF
--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -24,6 +24,10 @@ module LinuxAdmin
 
     private
 
+    def self.respond_to_missing?(method_name, include_private = false)
+      white_list_methods.include?(method_name)
+    end
+
     def self.registration_type_uncached
       if SubscriptionManager.new.registered?
         SubscriptionManager

--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -24,9 +24,10 @@ module LinuxAdmin
 
     private
 
-    def self.respond_to_missing?(method_name, include_private = false)
+    def self.respond_to_missing?(method_name, _include_private = false)
       white_list_methods.include?(method_name)
     end
+    private_class_method :respond_to_missing?
 
     def self.registration_type_uncached
       if SubscriptionManager.new.registered?

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -67,6 +67,14 @@ describe LinuxAdmin::RegistrationSystem do
     it "is an unknown method" do
       expect { LinuxAdmin::RegistrationSystem.method_does_not_exist }.to raise_error(NoMethodError)
     end
+
+    it "responds to whitelisted methods" do
+      expect(LinuxAdmin::RegistrationSystem).to respond_to(:refresh)
+    end
+
+    it "does not respond to methods that were not whitelisted" do
+      expect(LinuxAdmin::RegistrationSystem).to_not respond_to(:method_does_not_exist)
+    end
   end
 
   def stub_registered_to_system(*system)


### PR DESCRIPTION
Ruby best practices dictate that if you implement `method_missing` in a class, you should also implement a corresponding `respond_to_missing?` method.

So, this PR adds a `respond_to_missing?` private singleton method that checks for whitelisted methods. If found, it will return true, otherwise it will return false.

I've added a couple of specs as well.

Another reason to add this is that rspec will fail if run with strict partial validation in some of the core specs because dynamic methods aren't considered defined. You will see error messages like this:

```
19) MiqServer#enable_repos raises a notification for repos which fail to enable
      Failure/Error: expect(reg_system).to receive(:enable_repo).with("repo-1", anything).and_raise(err)
        LinuxAdmin::RegistrationSystem does not implement: enable_repo
      # ./spec/models/miq_server/update_management_spec.rb:217:in `block (3 levels) in <top (required)>'
```
Making this change eliminates those errors.