### PR TITLE
Add an option to enable and start a service in one step

### DIFF
--- a/lib/linux_admin/service/sys_v_init_service.rb
+++ b/lib/linux_admin/service/sys_v_init_service.rb
@@ -17,9 +17,10 @@ module LinuxAdmin
       self
     end
 
-    def start
+    def start(enable = false)
       Common.run!(Common.cmd(:service),
                   :params => {nil => [name, "start"]})
+      self.enable if enable
       self
     end
 

--- a/lib/linux_admin/service/systemd_service.rb
+++ b/lib/linux_admin/service/systemd_service.rb
@@ -14,8 +14,12 @@ module LinuxAdmin
       self
     end
 
-    def start
-      Common.run!(command_path, :params => ["start", name])
+    def start(enable = false)
+      if enable
+        Common.run!(command_path, :params => ["enable", "--now", name])
+      else
+        Common.run!(command_path, :params => ["start", name])
+      end
       self
     end
 

--- a/spec/service/sys_v_init_service_spec.rb
+++ b/spec/service/sys_v_init_service_spec.rb
@@ -64,6 +64,16 @@ describe LinuxAdmin::SysVInitService do
       @service.start
     end
 
+    it "also enables the service if passed true" do
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:service),
+              :params => {nil => %w(foo start)})
+      expect(LinuxAdmin::Common).to receive(:run!)
+        .with(LinuxAdmin::Common.cmd(:chkconfig),
+              :params => {nil => %w(foo on)})
+      @service.start(true)
+    end
+
     it "returns self" do
       expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.start).to eq(@service)

--- a/spec/service/systemd_service_spec.rb
+++ b/spec/service/systemd_service_spec.rb
@@ -53,6 +53,11 @@ describe LinuxAdmin::SystemdService do
       @service.start
     end
 
+    it "enables the service if passed true" do
+      expect(LinuxAdmin::Common).to receive(:run!).with(command, :params => %w(enable --now foo))
+      @service.start(true)
+    end
+
     it "returns self" do
       expect(LinuxAdmin::Common).to receive(:run!)
       expect(@service.start).to eq(@service)


### PR DESCRIPTION
For systemd services this uses the `systemctl enable --now` command
which avoids some issues we were seeing if we called enable followed
by start in quick succession.

For SysV services we just call chkconfig right after starting the
service

https://github.com/ManageIQ/manageiq/issues/10300

@simaishi