### PR TITLE
Update Disk size and model collection

### DIFF
--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -6,7 +6,7 @@ module LinuxAdmin
       [:id, :start_sector, :end_sector,
        :size, :partition_type, :fs_type]
 
-    attr_accessor :path, :model, :size
+    attr_accessor :path, :model
 
     def self.local
       result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE"})
@@ -20,6 +20,20 @@ module LinuxAdmin
       @path  = args[:path]
       @model = "unknown"
       @size  = args[:size]
+    end
+
+    def size
+      @size ||= begin
+        size = nil
+        out = Common.run!(Common.cmd(:fdisk), :params => {"-l" => nil}).output
+        out.each_line do |l|
+          /Disk #{path}: .*B, (\d+) bytes/.match(l) do |m|
+            size = m[1].to_i
+            break
+          end
+        end
+        size
+      end
     end
 
     def partitions

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -9,16 +9,17 @@ module LinuxAdmin
     attr_accessor :path, :model
 
     def self.local
-      result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE"})
-      result.output.split("\n").collect do |d|
-        path, size = d.split
-        self.new(:path => path, :size => size.to_i)
-      end
+      result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE,MODEL"})
+      result.output.split("\n").collect do |string|
+        path, size, *model = string.split
+        model = model.join(' ')
+        self.new(:path => path, :size => size.to_i, :model => model)
+      end.select { |disk| disk.size.nonzero? }
     end
 
     def initialize(args = {})
       @path  = args[:path]
-      @model = "unknown"
+      @model = args[:model] || "unknown"
       @size  = args[:size]
     end
 

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -8,12 +8,17 @@ module LinuxAdmin
 
     attr_accessor :path, :model
 
+    # Collect local disk information via the lsblk command. Only disks with a
+    # size greater than zero are returned.
+    #
     def self.local
-      result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE,MODEL"})
+      result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE,TYPE,MODEL"})
       result.output.split("\n").collect do |string|
-        path, size, *model = string.split
-        self.new(:path => path, :size => size.to_i, :model => model.join(' '))
-      end.select { |disk| disk.size.nonzero? }
+        path, size, type, *model = string.split
+        if type.casecmp?('disk') && size.to_i > 0
+          self.new(:path => path, :size => size.to_i, :model => model.join(' '))
+        end
+      end.compact
     end
 
     def initialize(args = {})

--- a/lib/linux_admin/disk.rb
+++ b/lib/linux_admin/disk.rb
@@ -12,8 +12,7 @@ module LinuxAdmin
       result = Common.run!(Common.cmd("lsblk"), :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE,MODEL"})
       result.output.split("\n").collect do |string|
         path, size, *model = string.split
-        model = model.join(' ')
-        self.new(:path => path, :size => size.to_i, :model => model)
+        self.new(:path => path, :size => size.to_i, :model => model.join(' '))
       end.select { |disk| disk.size.nonzero? }
     end
 

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -3,7 +3,7 @@ describe LinuxAdmin::Disk do
     it "returns local disks" do
       expect(LinuxAdmin::Common).to receive(:run!).with(
         LinuxAdmin::Common.cmd(:lsblk),
-        :params => {:d => nil, :n => nil, :p => nil, :o => "NAME"}
+        :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE"}
       ).and_return(double("result", :output => "/dev/hda\n/dev/sda"))
       disks = LinuxAdmin::Disk.local
       paths = disks.collect { |disk| disk.path }

--- a/spec/disk_spec.rb
+++ b/spec/disk_spec.rb
@@ -3,12 +3,17 @@ describe LinuxAdmin::Disk do
     it "returns local disks" do
       expect(LinuxAdmin::Common).to receive(:run!).with(
         LinuxAdmin::Common.cmd(:lsblk),
-        :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE"}
-      ).and_return(double("result", :output => "/dev/hda\n/dev/sda"))
+        :params => {:b => nil, :d => nil, :n => nil, :p => nil, :o => "NAME,SIZE,MODEL"}
+      ).and_return(double("result", :output => "/dev/hda 100000 samsung whatever\n/dev/sda 200000 western digital foo"))
       disks = LinuxAdmin::Disk.local
-      paths = disks.collect { |disk| disk.path }
-      expect(paths).to include('/dev/hda')
-      expect(paths).to include('/dev/sda')
+
+      expect(disks.first.path).to eql('/dev/hda')
+      expect(disks.first.size).to eql(100000)
+      expect(disks.first.model).to eql('samsung whatever')
+
+      expect(disks.last.path).to eql('/dev/sda')
+      expect(disks.last.size).to eql(200000)
+      expect(disks.last.model).to eql('western digital foo')
     end
   end
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/linux_admin/pull/211 in case you want to stick with the `lsblk` command.

Here I add the size via the `-b` option (bytes), as well as include the model information. This should be more efficient, too, since it means it won't have to make a separate `fdisk -l` call to get the size.

I've added specs to confirm the behavior.

https://bugzilla.redhat.com/show_bug.cgi?id=1693189