### PR TITLE
Update the search for the xml element we use for SCAP

### DIFF
--- a/lib/linux_admin/scap.rb
+++ b/lib/linux_admin/scap.rb
@@ -83,7 +83,7 @@ module LinuxAdmin
     end
 
     def model_xml_element(doc)
-      doc.css("//nist_list|model", "nist_list" => "http://checklists.nist.gov/xccdf/1.2").detect { |model| model.namespace.prefix.nil? }
+      doc.xpath("//ns10:model").first
     end
   end
 end


### PR DESCRIPTION
The format of the xml file has changed so the existing search was
not finding any results.

This search works as of scap-security-guide version 0.1.46

https://bugzilla.redhat.com/show_bug.cgi?id=1769901