### PR TITLE
clear_servers should include the default pool

### DIFF
--- a/lib/linux_admin/chrony.rb
+++ b/lib/linux_admin/chrony.rb
@@ -10,6 +10,7 @@ module LinuxAdmin
     def clear_servers
       data = File.read(@conf)
       data.gsub!(/^server\s+.+\n/, "")
+      data.gsub!(/^pool\s+.+\n/, "")
       File.write(@conf, data)
     end
 

--- a/spec/chrony_spec.rb
+++ b/spec/chrony_spec.rb
@@ -1,6 +1,7 @@
 describe LinuxAdmin::Chrony do
   CHRONY_CONF = <<-EOF
 # commented server baz.example.net
+pool bar.example.net iburst
 server foo.example.net
 server bar.example.net iburst
 driftfile /var/lib/chrony/drift


### PR DESCRIPTION
between 5.10 (RHEL 7) and 5.11 (RHEL 8) the default /etc/chrony.conf changed

it went from including a set of default servers to including a default pool

(this is an issue for private ntp servers that don't have internet connectivity
and it possibly should include a UI change later so we can handle this from the UI)
but i wanted to see if you all would let this in first

here are the bz links that this is tangentially referent to:
https://bugzilla.redhat.com/show_bug.cgi?id=1832278
https://bugzilla.redhat.com/show_bug.cgi?id=1757862
(yes, one of them is closed but we're going to ignore that cause it's valid work but don't tell Dennis or Josh)


## edit
~to be clear~, (*apparently not really*) ~this change of course doesn't fix that issue at all~ 
### lj says this is sufficient for the bz so i'm not about to argue 