### PR TITLE
bump more_core_extensions

### DIFF
--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -35,7 +35,7 @@ registration, updates, etc.
 
   spec.add_dependency "awesome_spawn",        "~> 1.3"
   spec.add_dependency "inifile"
-  spec.add_dependency "more_core_extensions", "~> 3.0"
+  spec.add_dependency "more_core_extensions", "~> 4.0"
   spec.add_dependency "nokogiri",             ">= 1.8.5", "!=1.10.0", "!=1.10.1", "!=1.10.2", "<2"
   spec.add_dependency "openscap"
   spec.add_dependency "net-ssh", "~> 4.2.0"


### PR DESCRIPTION
it's on 4.1.0

there's no particular reason, just update for update sake

https://github.com/ManageIQ/more_core_extensions/compare/179bf40..e5b4501
 - Added Ruby 2.7 support [[#79](https://github.com/ManageIQ/more_core_extensions/pull/79)]
 - Added Process#pause, Process#resume, and Process#alive? [[#73](https://github.com/ManageIQ/more_core_extensions/pull/73)]

array added * `#compact_map` - Collect non-nil results from the block
array added `#tabular_sort` - Sorts an Array of Hashes by specific columns

hierarchy  added `#descendant_get` - Returns the descendant with a given name

the two breaking changes: 
- **BREAKING**: Moved Object#descendant_get to Class#descendant_get [[#75](https://github.com/ManageIQ/more_core_extensions/pull/75)]
- **BREAKING**: Removed deprecated Enumerable#stable_sort_by [[#76](https://github.com/ManageIQ/more_core_extensions/pull/76)]

a minor header output change was made that hasn't been released yet to make tableize more markdown compliant 
