### PR TITLE
drop ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-- "2.4"
 - "2.5"
 - "2.6"
 - ruby-head


### PR DESCRIPTION
since we're not testing 2.4 in core, do we need it here?