### PR TITLE
Some rubocop fixes

### DIFF
--- a/lib/linux_admin/deb.rb
+++ b/lib/linux_admin/deb.rb
@@ -2,7 +2,7 @@ module LinuxAdmin
   class Deb < Package
     APT_CACHE_CMD = '/usr/bin/apt-cache'
 
-    def self.from_line(apt_cache_line, _in_description=false)
+    def self.from_line(apt_cache_line, _in_description = false)
       tag,value = apt_cache_line.split(':')
       tag = tag.strip.downcase
       [tag, value]

--- a/lib/linux_admin/deb.rb
+++ b/lib/linux_admin/deb.rb
@@ -2,7 +2,7 @@ module LinuxAdmin
   class Deb < Package
     APT_CACHE_CMD = '/usr/bin/apt-cache'
 
-    def self.from_line(apt_cache_line, in_description=false)
+    def self.from_line(apt_cache_line, _in_description=false)
       tag,value = apt_cache_line.split(':')
       tag = tag.strip.downcase
       [tag, value]

--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -54,7 +54,6 @@ module LinuxAdmin
       self
     end
 
-    private
 
     def self.bytes_to_string(bytes)
       if bytes > 1_073_741_824 # 1.gigabytes
@@ -68,7 +67,6 @@ module LinuxAdmin
       end
     end
 
-    public
 
     def self.create(name, vg, value)
       self.scan # initialize local logical volumes

--- a/lib/linux_admin/logical_volume.rb
+++ b/lib/linux_admin/logical_volume.rb
@@ -54,7 +54,6 @@ module LinuxAdmin
       self
     end
 
-
     def self.bytes_to_string(bytes)
       if bytes > 1_073_741_824 # 1.gigabytes
         (bytes / 1_073_741_824).to_s + "G"
@@ -67,6 +66,7 @@ module LinuxAdmin
       end
     end
 
+    private_class_method :bytes_to_string
 
     def self.create(name, vg, value)
       self.scan # initialize local logical volumes

--- a/lib/linux_admin/network_interface.rb
+++ b/lib/linux_admin/network_interface.rb
@@ -212,4 +212,4 @@ module LinuxAdmin
   end
 end
 
-Dir.glob(File.join(File.dirname(__FILE__), "network_interface", "*.rb")).each { |f| require f }
+Dir.glob(File.join(File.dirname(__FILE__), "network_interface", "*.rb")).sort.each { |f| require f }

--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -54,4 +54,4 @@ module LinuxAdmin
   end
 end
 
-Dir.glob(File.join(File.dirname(__FILE__), "registration_system", "*.rb")).each { |f| require f }
+Dir.glob(File.join(File.dirname(__FILE__), "registration_system", "*.rb")).sort.each { |f| require f }

--- a/lib/linux_admin/registration_system/subscription_manager.rb
+++ b/lib/linux_admin/registration_system/subscription_manager.rb
@@ -81,7 +81,7 @@ module LinuxAdmin
       parse_output(output).each_with_object({}) { |i, h| h[i[:pool_id]] = i }
     end
 
-    def enable_repo(repo, options = nil)
+    def enable_repo(repo, _options = nil)
       cmd     = "subscription-manager repos"
       params  = {"--enable=" => repo}
 
@@ -89,14 +89,14 @@ module LinuxAdmin
       run!(cmd, :params => params)
     end
 
-    def disable_repo(repo, options = nil)
+    def disable_repo(repo, _options = nil)
       cmd     = "subscription-manager repos"
       params  = {"--disable=" => repo}
 
       run!(cmd, :params => params)
     end
 
-    def all_repos(options = nil)
+    def all_repos(_options = nil)
       cmd     = "subscription-manager repos"
       output  = run!(cmd).output
 

--- a/lib/linux_admin/service.rb
+++ b/lib/linux_admin/service.rb
@@ -8,7 +8,6 @@ module LinuxAdmin
     end
 
     class << self
-      private
       alias_method :orig_new, :new
     end
 
@@ -38,4 +37,4 @@ module LinuxAdmin
   end
 end
 
-Dir.glob(File.join(File.dirname(__FILE__), "service", "*.rb")).each { |f| require f }
+Dir.glob(File.join(File.dirname(__FILE__), "service", "*.rb")).sort.each { |f| require f }

--- a/lib/linux_admin/service.rb
+++ b/lib/linux_admin/service.rb
@@ -9,6 +9,7 @@ module LinuxAdmin
 
     class << self
       alias_method :orig_new, :new
+      private :orig_new
     end
 
     def self.new(*args)

--- a/lib/linux_admin/volume.rb
+++ b/lib/linux_admin/volume.rb
@@ -1,6 +1,5 @@
 module LinuxAdmin
   class Volume
-
     def self.process_volume_display_line(line)
       groups = VolumeGroup.scan
       fields = line.split(':')
@@ -9,6 +8,7 @@ module LinuxAdmin
       return fields, vg
     end
 
+    private_class_method :process_volume_display_line
 
     def self.scan_volumes(cmd)
       volumes = []

--- a/lib/linux_admin/volume.rb
+++ b/lib/linux_admin/volume.rb
@@ -1,6 +1,5 @@
 module LinuxAdmin
   class Volume
-    private
 
     def self.process_volume_display_line(line)
       groups = VolumeGroup.scan
@@ -10,7 +9,6 @@ module LinuxAdmin
       return fields, vg
     end
 
-    protected
 
     def self.scan_volumes(cmd)
       volumes = []

--- a/lib/linux_admin/yum.rb
+++ b/lib/linux_admin/yum.rb
@@ -87,7 +87,6 @@ module LinuxAdmin
       parse_repo_list_output(output)
     end
 
-
     def self.parse_repo_dir(dir)
       repo_files = Dir.glob(File.join(dir, '*.repo'))
       repo_files.each_with_object({}) do |file, content|

--- a/lib/linux_admin/yum.rb
+++ b/lib/linux_admin/yum.rb
@@ -87,7 +87,6 @@ module LinuxAdmin
       parse_repo_list_output(output)
     end
 
-    private
 
     def self.parse_repo_dir(dir)
       repo_files = Dir.glob(File.join(dir, '*.repo'))
@@ -99,7 +98,7 @@ module LinuxAdmin
     def self.parse_repo_file(file)
       int_keys  = ["enabled", "cost", "gpgcheck", "sslverify", "metadata_expire"]
       content   = IniFile.load(file).to_h
-      content.each do |name, data|
+      content.each do |_name, data|
         int_keys.each { |k| data[k] = data[k].to_i if data.has_key?(k) }
       end
     end
@@ -122,4 +121,4 @@ module LinuxAdmin
   end
 end
 
-Dir.glob(File.join(File.dirname(__FILE__), "yum", "*.rb")).each { |f| require f }
+Dir.glob(File.join(File.dirname(__FILE__), "yum", "*.rb")).sort.each { |f| require f }


### PR DESCRIPTION
Some rubocop fixes. I just applied `rubocop -A` for this initial pass. Mostly it's unused variables. We can adjust as desired.

Mostly addresses https://github.com/ManageIQ/linux_admin/issues/224, but it does not yet fix the following:

```
lib/linux_admin/fstab.rb:102:7: W: Lint/MissingSuper: Call super to initialize state of the parent class.
      def initialize ...
      ^^^^^^^^^^^^^^
lib/linux_admin/logical_volume.rb:43:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(args = {}) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/linux_admin/null_logger.rb:5:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(*_args) ...
    ^^^^^^^^^^^^^^^^^^^^^^
lib/linux_admin/physical_volume.rb:22:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(args = {}) ...
```

Of those, the fstab one is trivial, but I'm not sure of the intent of the other 3.
