### PR TITLE
Fix Failing Build: update kwarg specs

### DIFF
--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -21,14 +21,14 @@ describe LinuxAdmin::Common do
 
   describe ".run" do
     it "runs a command with AwesomeSpawn.run" do
-      expect(AwesomeSpawn).to receive(:run).with("echo", nil => "test")
+      expect(AwesomeSpawn).to receive(:run).with("echo", {nil => "test"})
       described_class.run("echo", nil => "test")
     end
   end
 
   describe ".run!" do
     it "runs a command with AwesomeSpawn.run!" do
-      expect(AwesomeSpawn).to receive(:run!).with("echo", nil => "test")
+      expect(AwesomeSpawn).to receive(:run!).with("echo", {nil => "test"})
       described_class.run!("echo", nil => "test")
     end
   end

--- a/spec/registration_system_spec.rb
+++ b/spec/registration_system_spec.rb
@@ -38,11 +38,12 @@ describe LinuxAdmin::RegistrationSystem do
 
       it "with a proxy" do
         expect(LinuxAdmin::Common).to receive(:run).with(
-          "subscription-manager identity",
-          :params => {
-            "--proxy="         => "https://example.com",
-            "--proxyuser="     => "user",
-            "--proxypassword=" => "pass"
+          "subscription-manager identity", {
+            :params => {
+              "--proxy="         => "https://example.com",
+              "--proxyuser="     => "user",
+              "--proxypassword=" => "pass"
+            }
           }
         ).and_return(double(:exit_status => 0))
 

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -33,7 +33,8 @@ sV1Tr/acrE0aWBkD9RYrR2/UwG1zfXuIJeufdWf8c0SY3X6J7jJN
   end
 
   it "should create a call using agent" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :forward_agent => true, :number_of_password_prompts => 0, :agent_socket_factory => Proc).and_return(true)
+    # TODO: capture/eat "Identity added: (stdin) ((stdin))""
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", {:verify_host_key => false, :forward_agent => true, :number_of_password_prompts => 0, :agent_socket_factory => Proc}).and_return(true)
     ssh_agent = LinuxAdmin::SSHAgent.new(@example_ssh_key)
     ssh_agent.with_service do |socket|
       ssh = LinuxAdmin::SSH.new("127.0.0.1", "root")
@@ -42,12 +43,12 @@ sV1Tr/acrE0aWBkD9RYrR2/UwG1zfXuIJeufdWf8c0SY3X6J7jJN
   end
 
   it "should preform command using private key" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :number_of_password_prompts => 0, :key_data => [@example_ssh_key]).and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", {:verify_host_key => false, :number_of_password_prompts => 0, :key_data => [@example_ssh_key]}).and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", @example_ssh_key).perform_commands(%w("ls", "pwd"))
   end
 
   it "should preform command using password" do
-    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", :verify_host_key => false, :number_of_password_prompts => 0, :password => "password").and_return(true)
+    expect(Net::SSH).to receive(:start).with("127.0.0.1", "root", {:verify_host_key => false, :number_of_password_prompts => 0, :password => "password"}).and_return(true)
     LinuxAdmin::SSH.new("127.0.0.1", "root", nil, "password").perform_commands(%w("ls", "pwd"))
   end
 end

--- a/spec/subscription_manager_spec.rb
+++ b/spec/subscription_manager_spec.rb
@@ -19,14 +19,17 @@ describe LinuxAdmin::SubscriptionManager do
 
   context "#registered?" do
     it "system with subscription-manager commands" do
-      expect(LinuxAdmin::Common).to receive(:run).once.with("subscription-manager identity")
-        .and_return(double(:exit_status => 0))
+      expect(LinuxAdmin::Common).to(
+        receive(:run).once.with("subscription-manager identity")
+                     .and_return(double(:exit_status => 0))
+      )
       expect(described_class.new.registered?).to be_truthy
     end
 
     it "system without subscription-manager commands" do
-      expect(LinuxAdmin::Common).to receive(:run).once.with("subscription-manager identity")
-        .and_return(double(:exit_status => 255))
+      expect(LinuxAdmin::Common).to(
+        receive(:run).once.with("subscription-manager identity").and_return(double(:exit_status => 255))
+      )
       expect(described_class.new.registered?).to be_falsey
     end
   end
@@ -42,16 +45,29 @@ describe LinuxAdmin::SubscriptionManager do
     end
 
     context "with username and password" do
-      let(:base_options) { {:username       => "SomeUser@SomeDomain.org",
-                            :password       => "SomePass",
-                            :environment    => "Library",
-                            :org            => "IT",
-                            :proxy_address  => "1.2.3.4",
-                            :proxy_username => "ProxyUser",
-                            :proxy_password => "ProxyPass",
-                          }
-                        }
-      let(:run_params) { {:params=>{"--username="=>"SomeUser@SomeDomain.org", "--password="=>"SomePass", "--proxy="=>"1.2.3.4", "--proxyuser="=>"ProxyUser", "--proxypassword="=>"ProxyPass", "--environment="=>"Library"}} }
+      let(:base_options) do
+        {
+          :username       => "SomeUser@SomeDomain.org",
+          :password       => "SomePass",
+          :environment    => "Library",
+          :org            => "IT",
+          :proxy_address  => "1.2.3.4",
+          :proxy_username => "ProxyUser",
+          :proxy_password => "ProxyPass",
+        }
+      end
+      let(:run_params) do
+        {
+          :params => {
+            "--username="      => "SomeUser@SomeDomain.org",
+            "--password="      => "SomePass",
+            "--proxy="         => "1.2.3.4",
+            "--proxyuser="     => "ProxyUser",
+            "--proxypassword=" => "ProxyPass",
+            "--environment="   => "Library"
+          }
+        }
+      end
 
       it "with server_url" do
         run_params.store_path(:params, "--org=", "IT")
@@ -74,117 +90,145 @@ describe LinuxAdmin::SubscriptionManager do
 
   context "#subscribe" do
     it "with pools" do
-      expect(LinuxAdmin::Common).to receive(:run!).once
-        .with("subscription-manager attach", {:params => [["--pool", 123], ["--pool", 456]]})
+      expect(LinuxAdmin::Common).to(
+        receive(:run!).once.with("subscription-manager attach", {:params => [["--pool", 123], ["--pool", 456]]})
+      )
       described_class.new.subscribe({:pools => [123, 456]})
     end
 
     it "without pools" do
-      expect(LinuxAdmin::Common).to receive(:run!).once
-        .with("subscription-manager attach", {:params => {"--auto" => nil}})
+      expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager attach", {:params => {"--auto" => nil}})
       described_class.new.subscribe({})
     end
   end
 
   context "#subscribed_products" do
     it "subscribed" do
-      expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager list --installed", {})
-        .and_return(double(:output => sample_output("subscription_manager/output_list_installed_subscribed")))
+      expect(LinuxAdmin::Common).to(
+        receive(:run!).once.with("subscription-manager list --installed", {})
+                      .and_return(double(:output => sample_output("subscription_manager/output_list_installed_subscribed")))
+      )
       expect(described_class.new.subscribed_products).to eq(["69", "167"])
     end
 
     it "not subscribed" do
-      expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager list --installed", {})
-        .and_return(double(:output => sample_output("subscription_manager/output_list_installed_not_subscribed")))
+      expect(LinuxAdmin::Common).to(
+        receive(:run!).once.with("subscription-manager list --installed", {})
+                      .and_return(double(:output => sample_output("subscription_manager/output_list_installed_not_subscribed")))
+      )
       expect(described_class.new.subscribed_products).to eq(["167"])
     end
   end
 
   it "#available_subscriptions" do
-    expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager list --all --available", {})
-      .and_return(double(:output => sample_output("subscription_manager/output_list_all_available")))
-    expect(described_class.new.available_subscriptions).to eq({
-      "82c042fca983889b10178893f29b06e3" => {
-        :subscription_name => "Example Subscription",
-        :sku               => "SER0123",
-        :pool_id           => "82c042fca983889b10178893f29b06e3",
-        :quantity          => "1690",
-        :service_level     => "None",
-        :service_type      => "None",
-        :multi_entitlement => "No",
-        :ends              => Date.parse("2022-01-01"),
-        :system_type       => "Physical",
-      },
-      "4f738052ec866192c775c62f408ab868" => {
-        :subscription_name => "My Private Subscription",
-        :sku               => "SER9876",
-        :pool_id           => "4f738052ec866192c775c62f408ab868",
-        :quantity          => "Unlimited",
-        :service_level     => "None",
-        :service_type      => "None",
-        :multi_entitlement => "No",
-        :ends              => Date.parse("2013-06-04"),
-        :system_type       => "Virtual",
-      },
-      "3d81297f352305b9a3521981029d7d83" => {
-        :subscription_name => "Shared Subscription - With other characters, (2 sockets) (Up to 1 guest)",
-        :sku               => "RH0123456",
-        :pool_id           => "3d81297f352305b9a3521981029d7d83",
-        :quantity          => "1",
-        :service_level     => "Self-support",
-        :service_type      => "L1-L3",
-        :multi_entitlement => "No",
-        :ends              => Date.parse("2013-05-15"),
-        :system_type       => "Virtual",
-      },
-      "87cefe63b67984d5c7e401d833d2f87f" => {
-        :subscription_name => "Example Subscription, Premium (up to 2 sockets) 3 year",
-        :sku               => "MCT0123A9",
-        :pool_id           => "87cefe63b67984d5c7e401d833d2f87f",
-        :quantity          => "1",
-        :service_level     => "Premium",
-        :service_type      => "L1-L3",
-        :multi_entitlement => "No",
-        :ends              => Date.parse("2013-07-05"),
-        :system_type       => "Virtual",
-      },
-    })
+    expect(LinuxAdmin::Common).to(
+      receive(:run!).once.with("subscription-manager list --all --available", {})
+                    .and_return(double(:output => sample_output("subscription_manager/output_list_all_available")))
+    )
+    expect(described_class.new.available_subscriptions).to eq(
+      {
+        "82c042fca983889b10178893f29b06e3" => {
+          :subscription_name => "Example Subscription",
+          :sku               => "SER0123",
+          :pool_id           => "82c042fca983889b10178893f29b06e3",
+          :quantity          => "1690",
+          :service_level     => "None",
+          :service_type      => "None",
+          :multi_entitlement => "No",
+          :ends              => Date.parse("2022-01-01"),
+          :system_type       => "Physical",
+        },
+        "4f738052ec866192c775c62f408ab868" => {
+          :subscription_name => "My Private Subscription",
+          :sku               => "SER9876",
+          :pool_id           => "4f738052ec866192c775c62f408ab868",
+          :quantity          => "Unlimited",
+          :service_level     => "None",
+          :service_type      => "None",
+          :multi_entitlement => "No",
+          :ends              => Date.parse("2013-06-04"),
+          :system_type       => "Virtual",
+        },
+        "3d81297f352305b9a3521981029d7d83" => {
+          :subscription_name => "Shared Subscription - With other characters, (2 sockets) (Up to 1 guest)",
+          :sku               => "RH0123456",
+          :pool_id           => "3d81297f352305b9a3521981029d7d83",
+          :quantity          => "1",
+          :service_level     => "Self-support",
+          :service_type      => "L1-L3",
+          :multi_entitlement => "No",
+          :ends              => Date.parse("2013-05-15"),
+          :system_type       => "Virtual",
+        },
+        "87cefe63b67984d5c7e401d833d2f87f" => {
+          :subscription_name => "Example Subscription, Premium (up to 2 sockets) 3 year",
+          :sku               => "MCT0123A9",
+          :pool_id           => "87cefe63b67984d5c7e401d833d2f87f",
+          :quantity          => "1",
+          :service_level     => "Premium",
+          :service_type      => "L1-L3",
+          :multi_entitlement => "No",
+          :ends              => Date.parse("2013-07-05"),
+          :system_type       => "Virtual",
+        },
+      }
+    )
   end
 
   context "#organizations" do
     it "with valid credentials" do
-      run_options = ["subscription-manager orgs", {:params=>{"--username="=>"SomeUser", "--password="=>"SomePass", "--proxy="=>"1.2.3.4", "--proxyuser="=>"ProxyUser", "--proxypassword="=>"ProxyPass"}}]
+      run_options = ["subscription-manager orgs", {
+        :params => {
+          "--username="      => "SomeUser",
+          "--password="      => "SomePass",
+          "--proxy="         => "1.2.3.4",
+          "--proxyuser="     => "ProxyUser",
+          "--proxypassword=" => "ProxyPass"
+        }
+      }]
 
       expect(LinuxAdmin::Rpm).to receive(:upgrade).with("http://192.168.1.1/pub/katello-ca-consumer-latest.noarch.rpm")
-      expect(LinuxAdmin::Common).to receive(:run!).once.with(*run_options)
-        .and_return(double(:output => sample_output("subscription_manager/output_orgs")))
+      expect(LinuxAdmin::Common).to(
+        receive(:run!).once.with(*run_options).and_return(double(:output => sample_output("subscription_manager/output_orgs")))
+      )
 
-      expect(described_class.new.organizations({:username=>"SomeUser", :password=>"SomePass", :proxy_address=>"1.2.3.4", :proxy_username=>"ProxyUser", :proxy_password=>"ProxyPass", :server_url=>"192.168.1.1"})).to eq({"SomeOrg"=>{:name=>"SomeOrg", :key=>"1234567"}})
+      manager = described_class.new.organizations(
+        :username       => "SomeUser",
+        :password       => "SomePass",
+        :proxy_address  => "1.2.3.4",
+        :proxy_username => "ProxyUser",
+        :proxy_password => "ProxyPass",
+        :server_url     => "192.168.1.1"
+      )
+      expect(manager).to eq({"SomeOrg" => {:name => "SomeOrg", :key => "1234567"}})
     end
 
     it "with invalid credentials" do
-      run_options = ["subscription-manager orgs", {:params=>{"--username="=>"BadUser", "--password="=>"BadPass"}}]
-      error = AwesomeSpawn::CommandResultError.new("",
+      run_options = ["subscription-manager orgs", {:params => {"--username=" => "BadUser", "--password=" => "BadPass"}}]
+      error = AwesomeSpawn::CommandResultError.new(
+        "",
         double(
           :error       => "Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html",
           :exit_status => 255
         )
       )
       expect(AwesomeSpawn).to receive(:run!).once.with(*run_options).and_raise(error)
-      expect { described_class.new.organizations({:username=>"BadUser", :password=>"BadPass"}) }.to raise_error(LinuxAdmin::CredentialError)
+      expect { described_class.new.organizations({:username => "BadUser", :password => "BadPass"}) }.to raise_error(LinuxAdmin::CredentialError)
     end
   end
 
   it "#enable_repo" do
-    expect(LinuxAdmin::Common).to receive(:run!).once
-      .with("subscription-manager repos", {:params => {"--enable=" => "abc"}})
+    expect(LinuxAdmin::Common).to(
+      receive(:run!).once.with("subscription-manager repos", {:params => {"--enable=" => "abc"}})
+    )
 
     described_class.new.enable_repo("abc")
   end
 
   it "#disable_repo" do
-    expect(LinuxAdmin::Common).to receive(:run!).once
-      .with("subscription-manager repos", {:params => {"--disable=" => "abc"}})
+    expect(LinuxAdmin::Common).to(
+      receive(:run!).once.with("subscription-manager repos", {:params => {"--disable=" => "abc"}})
+    )
 
     described_class.new.disable_repo("abc")
   end
@@ -211,8 +255,10 @@ describe LinuxAdmin::SubscriptionManager do
       }
     ]
 
-    expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager repos", {})
-      .and_return(double(:output => sample_output("subscription_manager/output_repos")))
+    expect(LinuxAdmin::Common).to(
+      receive(:run!).once.with("subscription-manager repos", {})
+                    .and_return(double(:output => sample_output("subscription_manager/output_repos")))
+    )
 
     expect(described_class.new.all_repos).to eq(expected)
   end
@@ -220,8 +266,10 @@ describe LinuxAdmin::SubscriptionManager do
   it "#enabled_repos" do
     expected = ["some-repo-source-rpms", "some-repo-rpms"]
 
-    expect(LinuxAdmin::Common).to receive(:run!).once.with("subscription-manager repos", {})
-      .and_return(double(:output => sample_output("subscription_manager/output_repos")))
+    expect(LinuxAdmin::Common).to(
+      receive(:run!).once.with("subscription-manager repos", {})
+                    .and_return(double(:output => sample_output("subscription_manager/output_repos")))
+    )
 
     expect(described_class.new.enabled_repos).to eq(expected)
   end

--- a/spec/subscription_manager_spec.rb
+++ b/spec/subscription_manager_spec.rb
@@ -75,13 +75,13 @@ describe LinuxAdmin::SubscriptionManager do
   context "#subscribe" do
     it "with pools" do
       expect(LinuxAdmin::Common).to receive(:run!).once
-        .with("subscription-manager attach", :params => [["--pool", 123], ["--pool", 456]])
+        .with("subscription-manager attach", {:params => [["--pool", 123], ["--pool", 456]]})
       described_class.new.subscribe({:pools => [123, 456]})
     end
 
     it "without pools" do
       expect(LinuxAdmin::Common).to receive(:run!).once
-        .with("subscription-manager attach", :params => {"--auto" => nil})
+        .with("subscription-manager attach", {:params => {"--auto" => nil}})
       described_class.new.subscribe({})
     end
   end
@@ -177,14 +177,14 @@ describe LinuxAdmin::SubscriptionManager do
 
   it "#enable_repo" do
     expect(LinuxAdmin::Common).to receive(:run!).once
-      .with("subscription-manager repos", :params => {"--enable=" => "abc"})
+      .with("subscription-manager repos", {:params => {"--enable=" => "abc"}})
 
     described_class.new.enable_repo("abc")
   end
 
   it "#disable_repo" do
     expect(LinuxAdmin::Common).to receive(:run!).once
-      .with("subscription-manager repos", :params => {"--disable=" => "abc"})
+      .with("subscription-manager repos", {:params => {"--disable=" => "abc"}})
 
     described_class.new.disable_repo("abc")
   end


### PR DESCRIPTION
Fixes failing build:

- `expect().with()` now distinguishes between kwargs and args. It requires `{}`
- Fixed all cops in one of the affected files.
