### PR TITLE
Use system path instead of hardcoding it.

### DIFF
--- a/lib/linux_admin/common.rb
+++ b/lib/linux_admin/common.rb
@@ -4,7 +4,7 @@ module LinuxAdmin
   module Common
     include Logging
 
-    BIN_DIRS = %w(/bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin)
+    BIN_DIRS = ENV["PATH"].split(File::PATH_SEPARATOR).freeze
 
     def self.cmd(name)
       BIN_DIRS.collect { |dir| "#{dir}/#{name}" }.detect { |cmd| File.exist?(cmd) }


### PR DESCRIPTION
depends upon:
- [x] https://github.com/ManageIQ/linux_admin/pull/232 (this is the first commit)

Introducing this so I can run tests on my mac.

alt:
- add `/opt/homebrew/bin` to `BIN_DIRS` which is in essence, the new `/usr/local/bin`