### PR TITLE
Change redirects to be portable

### DIFF
--- a/lib/linux_admin/ssh_agent.rb
+++ b/lib/linux_admin/ssh_agent.rb
@@ -32,7 +32,7 @@ module LinuxAdmin
     end
 
     def stop
-      system({'SSH_AGENT_PID' => @pid}, '(ssh-agent -k) &> /dev/null') if process_exists?(@pid)
+      system({'SSH_AGENT_PID' => @pid}, '(ssh-agent -k) >/dev/null 2>&1') if process_exists?(@pid)
       File.delete(@socket) if File.exist?(@socket)
       @socket = nil
       @pid = nil


### PR DESCRIPTION
Since the underlying shell used by system can be different, prefer a portable version of redirection as &> is shell specific

@agrare Please review.