### PR TITLE
Fix AwesomeSpawn spec failures

### DIFF
--- a/spec/hosts_spec.rb
+++ b/spec/hosts_spec.rb
@@ -136,13 +136,13 @@ EOT
     end
 
     it "returns the hostname" do
-      result = AwesomeSpawn::CommandResult.new("", TEST_HOSTNAME, nil, 0)
+      result = AwesomeSpawn::CommandResult.new("", TEST_HOSTNAME, "", 55, 0)
       expect(AwesomeSpawn).to receive(:run).with(*spawn_args).and_return(result)
       expect(@instance.hostname).to eq(TEST_HOSTNAME)
     end
 
     it "returns nil when the command fails" do
-      result = AwesomeSpawn::CommandResult.new("", "", "An error has happened", 1)
+      result = AwesomeSpawn::CommandResult.new("", "", "An error has happened", 55, 1)
       expect(AwesomeSpawn).to receive(:run).with(*spawn_args).and_return(result)
       expect(@instance.hostname).to be_nil
     end

--- a/spec/ip_address_spec.rb
+++ b/spec/ip_address_spec.rb
@@ -49,7 +49,7 @@ default via 192.168.1.1 dev eth0  proto static  metric 100
 IP_OUT
 
   def result(output, exit_status)
-    AwesomeSpawn::CommandResult.new("", output, "", exit_status)
+    AwesomeSpawn::CommandResult.new("", output, "", 55, exit_status)
   end
 
   describe "#address" do

--- a/spec/network_interface/network_interface_rh_spec.rb
+++ b/spec/network_interface/network_interface_rh_spec.rb
@@ -34,7 +34,7 @@ EOF
   end
 
   def result(output, exit_status)
-    AwesomeSpawn::CommandResult.new("", output, "", exit_status)
+    AwesomeSpawn::CommandResult.new("", output, "", 55, exit_status)
   end
 
   subject(:dhcp_interface) do

--- a/spec/network_interface_spec.rb
+++ b/spec/network_interface_spec.rb
@@ -146,7 +146,7 @@ IP_OUT
     end
 
     def result(output, exit_status)
-      AwesomeSpawn::CommandResult.new("", output, "", exit_status)
+      AwesomeSpawn::CommandResult.new("", output, "", nil, exit_status)
     end
 
     describe "#reload" do

--- a/spec/rpm_spec.rb
+++ b/spec/rpm_spec.rb
@@ -59,7 +59,7 @@ files and to do system management tasks (as in Perl).  It is simple,
 straight-forward, and extensible.
 EOS
       arguments = [described_class.rpm_cmd, :params => {"-qi" => "ruby"}]
-      result = AwesomeSpawn::CommandResult.new("", data, "", 0)
+      result = AwesomeSpawn::CommandResult.new("", data, "", 55, 0)
       expect(LinuxAdmin::Common).to receive(:run!).with(*arguments).and_return(result)
       metadata = described_class.info("ruby")
       expect(metadata['name']).to eq('ruby')

--- a/spec/subscription_manager_spec.rb
+++ b/spec/subscription_manager_spec.rb
@@ -1,7 +1,7 @@
 describe LinuxAdmin::SubscriptionManager do
   context "#run!" do
     it "raises a CredentialError if the error message contained a credential error" do
-      result = AwesomeSpawn::CommandResult.new("stuff", "things", "invalid username or password", 1)
+      result = AwesomeSpawn::CommandResult.new("stuff", "things", "invalid username or password", 55, 1)
       err = AwesomeSpawn::CommandResultError.new("things", result)
       expect(LinuxAdmin::Common).to receive(:run!).and_raise(err)
 
@@ -9,7 +9,7 @@ describe LinuxAdmin::SubscriptionManager do
     end
 
     it "raises a SubscriptionManagerError if the error message does not contain a credential error" do
-      result = AwesomeSpawn::CommandResult.new("stuff", "things", "not a credential error", 1)
+      result = AwesomeSpawn::CommandResult.new("stuff", "things", "not a credential error", 55, 1)
       err = AwesomeSpawn::CommandResultError.new("things", result)
       expect(LinuxAdmin::Common).to receive(:run!).and_raise(err)
 
@@ -205,12 +205,10 @@ describe LinuxAdmin::SubscriptionManager do
 
     it "with invalid credentials" do
       run_options = ["subscription-manager orgs", {:params => {"--username=" => "BadUser", "--password=" => "BadPass"}}]
+      result = AwesomeSpawn::CommandResult.new("", "", "Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html", 55, 255)
       error = AwesomeSpawn::CommandResultError.new(
         "",
-        double(
-          :error       => "Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html",
-          :exit_status => 255
-        )
+        result
       )
       expect(AwesomeSpawn).to receive(:run!).once.with(*run_options).and_raise(error)
       expect { described_class.new.organizations({:username => "BadUser", :password => "BadPass"}) }.to raise_error(LinuxAdmin::CredentialError)

--- a/spec/time_date_spec.rb
+++ b/spec/time_date_spec.rb
@@ -3,7 +3,7 @@ describe LinuxAdmin::TimeDate do
 
   def timedatectl_result
     output = File.read(Pathname.new(data_file_path("time_date/timedatectl_output")))
-    AwesomeSpawn::CommandResult.new("", output, "", 0)
+    AwesomeSpawn::CommandResult.new("", output, "", 55, 0)
   end
 
   describe ".system_timezone_detailed" do
@@ -56,7 +56,7 @@ America/Argentina/Ushuaia
         RUN_COMMAND,
         :params => ["list-timezones"]
       ]
-      result = AwesomeSpawn::CommandResult.new("", timezones, "", 0)
+      result = AwesomeSpawn::CommandResult.new("", timezones, "", 55, 0)
       expect(AwesomeSpawn).to receive(:run!).with(*awesome_spawn_args).and_return(result)
       expect(described_class.timezones).to eq(timezones.split("\n"))
     end

--- a/spec/yum_spec.rb
+++ b/spec/yum_spec.rb
@@ -97,18 +97,18 @@ describe LinuxAdmin::Yum do
   context ".update" do
     it "no arguments" do
       expect(LinuxAdmin::Common).to receive(:run!).once.with("yum -y update", :params => nil)
-        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
+        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 55, 0))
       described_class.update
     end
 
     it "with arguments" do
       expect(LinuxAdmin::Common).to receive(:run!).once.with("yum -y update", :params => {nil => ["1 2", "3"]})
-        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 0))
+        .and_return(AwesomeSpawn::CommandResult.new("", "", "", 55, 0))
       described_class.update("1 2", "3")
     end
 
     it "with bad arguments" do
-      error = AwesomeSpawn::CommandResult.new("", "Loaded plugins: product-id\nNo Packages marked for Update\n", "Blah blah ...\nNo Match for argument: \n", 0)
+      error = AwesomeSpawn::CommandResult.new("", "Loaded plugins: product-id\nNo Packages marked for Update\n", "Blah blah ...\nNo Match for argument: \n", 55, 0)
       expect(LinuxAdmin::Common).to receive(:run!).once
         .with("yum -y update", :params => {nil => [""]}).and_return(error)
       expect { described_class.update("") }.to raise_error(AwesomeSpawn::CommandResultError)


### PR DESCRIPTION
AwesomeSpawn::CommandResult used to take 4 parameters but now takes 5
This was a change in the internal api for awesomespawn

In the future, we may want to converting over to using "awesome_spawn/spec_helper" and the stub_good_run stuff
