### PR TITLE
Bump awesome_spawn minimum to 1.6

### DIFF
--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -33,7 +33,7 @@ registration, updates, etc.
   spec.add_development_dependency "rspec",    "~> 3.0"
   spec.add_development_dependency "rubocop"
 
-  spec.add_dependency "awesome_spawn",        "~> 1.3"
+  spec.add_dependency "awesome_spawn",        "~> 1.6"
   spec.add_dependency "inifile"
   spec.add_dependency "more_core_extensions", "~> 4.0"
   spec.add_dependency "net-ssh", "~> 4.2.0"


### PR DESCRIPTION
The change in #238 uses the interface from 1.6, so we need to enforce that as the minimum.

Based on https://github.com/ManageIQ/linux_admin/pull/238#issuecomment-1934622151

@agrare Please review.
