### PR TITLE
Bump net-ssh for OpenSSL 3.0 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.5'
         - '2.6'
         - '2.7'
         - '3.0'

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -34,9 +34,11 @@ registration, updates, etc.
   spec.add_development_dependency "rubocop"
 
   spec.add_dependency "awesome_spawn",        "~> 1.6"
+  spec.add_dependency "bcrypt_pbkdf",         ">= 1.0", "< 2.0"
+  spec.add_dependency "ed25519",              ">= 1.2", "< 1.3"
   spec.add_dependency "inifile"
   spec.add_dependency "more_core_extensions", "~> 4.0"
-  spec.add_dependency "net-ssh", "~> 4.2.0"
+  spec.add_dependency "net-ssh",              "~> 7.2.3"
   spec.add_dependency "nokogiri",             ">= 1.8.5", "!=1.10.0", "!=1.10.1", "!=1.10.2", "<2"
   spec.add_dependency "openscap"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -26,7 +26,7 @@ registration, updates, etc.
   spec.executables   = `git ls-files -- bin/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Also add support for `ed25519` type ssh keys

Related:
- https://github.com/ManageIQ/manageiq-appliance_console/issues/245
- https://github.com/ManageIQ/manageiq-ssh-util/pull/21

Required for: https://github.com/ManageIQ/manageiq-appliance_console/pull/248
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
