### PR TITLE
Fix local spec failures on ruby 3.1

### DIFF
--- a/lib/linux_admin/registration_system.rb
+++ b/lib/linux_admin/registration_system.rb
@@ -47,7 +47,8 @@ module LinuxAdmin
     private_class_method :white_list_methods
 
     def install_server_certificate(server, cert_path)
-      host = server.start_with?("http") ? URI.parse(server).host : server
+      require 'uri'
+      host = server.start_with?("http") ? ::URI.parse(server).host : server
 
       LinuxAdmin::Rpm.upgrade("http://#{host}/#{cert_path}")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
   end
 end
 
+require 'rspec/support/differ'
 require 'linux_admin'
 
 def etc_issue_contains(contents)


### PR DESCRIPTION
```
Failures:

  1) LinuxAdmin::EtcIssue should find upper phrase in file
     Failure/Error: expect(subject).to include("phrase")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:30:in `block (2 levels) in <top (required)>'

  2) LinuxAdmin::EtcIssue should not find phrase when the file has a different phrase
     Failure/Error: expect(subject).not_to include("phrase")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:20:in `block (2 levels) in <top (required)>'

  3) LinuxAdmin::EtcIssue should find phrase when searching with upper
     Failure/Error: expect(subject).to include("PHRASE")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:35:in `block (2 levels) in <top (required)>'

  4) LinuxAdmin::EtcIssue should not find the phrase when the file is missing
     Failure/Error: expect(subject).not_to include("phrase")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:10:in `block (2 levels) in <top (required)>'

  5) LinuxAdmin::EtcIssue should not find phrase when the file is empty
     Failure/Error: expect(subject).not_to include("phrase")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:15:in `block (2 levels) in <top (required)>'

  6) LinuxAdmin::EtcIssue should find phrase in same case
     Failure/Error: expect(subject).to include("phrase")

     NameError:
       uninitialized constant RSpec::Support::Differ
     # ./spec/etc_issue_spec.rb:25:in `block (2 levels) in <top (required)>'

  7) LinuxAdmin::SubscriptionManager#register with username and password with server_url
     Failure/Error: host = server.start_with?("http") ? ::URI.parse(server).host : server

     NameError:
       uninitialized constant URI
     # ./lib/linux_admin/registration_system.rb:50:in `install_server_certificate'
     # ./lib/linux_admin/registration_system/subscription_manager.rb:45:in `register'
     # ./spec/subscription_manager_spec.rb:79:in `block (4 levels) in <top (required)>'

Finished in 0.30563 seconds (files took 0.30077 seconds to load) 316 examples, 7 failures

Failed examples:

rspec ./spec/etc_issue_spec.rb:28 # LinuxAdmin::EtcIssue should find upper phrase in file rspec ./spec/etc_issue_spec.rb:18 # LinuxAdmin::EtcIssue should not find phrase when the file has a different phrase rspec ./spec/etc_issue_spec.rb:33 # LinuxAdmin::EtcIssue should find phrase when searching with upper rspec ./spec/etc_issue_spec.rb:8 # LinuxAdmin::EtcIssue should not find the phrase when the file is missing rspec ./spec/etc_issue_spec.rb:13 # LinuxAdmin::EtcIssue should not find phrase when the file is empty rspec ./spec/etc_issue_spec.rb:23 # LinuxAdmin::EtcIssue should find phrase in same case rspec ./spec/subscription_manager_spec.rb:72 # LinuxAdmin::SubscriptionManager#register with username and password with server_url

Randomized with seed 36320
```
