### PR TITLE
Parse config file on NetworkInterface#reload

### DIFF
--- a/lib/linux_admin/network_interface/network_interface_rh.rb
+++ b/lib/linux_admin/network_interface/network_interface_rh.rb
@@ -12,7 +12,15 @@ module LinuxAdmin
     def initialize(interface)
       @interface_file = self.class.path_to_interface_config_file(interface)
       super
+    end
+
+    # Gathers current network information for this interface
+    #
+    # @return [Boolean] true if network information was gathered successfully
+    def reload
+      super
       parse_conf
+      true
     end
 
     # Parses the interface configuration file into the @interface_config hash


### PR DESCRIPTION
I haven't checked other callers of reload to see if this makes sense so I'd like your opinions @bdunne / @Fryguy but I was looking at https://github.com/ManageIQ/manageiq-appliance_console/blob/master/bin/appliance_console#L92-L93 and the `.reload` then `.parse_conf if respond_to?(:parse_conf)` looked like it could be improved by moving this logic into the NetworkInterfaceRh subclass.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
