### PR TITLE
Bump more_core_extensions to 4.5.1 minimum

### DIFF
--- a/linux_admin.gemspec
+++ b/linux_admin.gemspec
@@ -37,7 +37,7 @@ registration, updates, etc.
   spec.add_dependency "bcrypt_pbkdf",         ">= 1.0", "< 2.0"
   spec.add_dependency "ed25519",              ">= 1.2", "< 2.0"
   spec.add_dependency "inifile"
-  spec.add_dependency "more_core_extensions", "~> 4.0"
+  spec.add_dependency "more_core_extensions", "~> 4.5", ">= 4.5.1"
   spec.add_dependency "net-ssh",              "~> 7.2.3"
   spec.add_dependency "nokogiri",             ">= 1.8.5", "!=1.10.0", "!=1.10.1", "!=1.10.2", "<2"
   spec.add_dependency "openscap"


### PR DESCRIPTION
This is to bring in the latest changes fixing the require of logger on active_support < 7.0

@agrare Please review.